### PR TITLE
AI Player 1.20.6 -> 1.21.1 Port

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,13 +105,13 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 17
+	it.options.release = 21
 }
 
 java {
 	withSourcesJar()
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_21
+	targetCompatibility = JavaVersion.VERSION_21
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,16 +5,16 @@ org.gradle.parallel=true
 # Fabric Properties
 # check these on https://fabricmc.net/develop
 # Updated versions for better Java 21 compatibility
-minecraft_version=1.20.6
-yarn_mappings=1.20.6+build.3
+minecraft_version=1.21.1
+yarn_mappings=1.21.1+build.3
 loader_version=0.16.14
 loom_version=1.11-SNAPSHOT
 
 # Mod Properties (keep your existing values)
-mod_version=1.0.5.1-release+1.20.6-bugfix-2
+mod_version=1.0.5.2-release+1.21.1
 maven_group=net.shasankp000
 archives_base_name=ai-player
 
 # Dependencies
-fabric_version=0.100.8+1.20.6
+fabric_version=0.116.6+1.21.1
 

--- a/src/main/java/net/shasankp000/Commands/modCommandRegistry.java
+++ b/src/main/java/net/shasankp000/Commands/modCommandRegistry.java
@@ -896,7 +896,7 @@ public class modCommandRegistry {
 
             BlockPos currentPosition = bot.getBlockPos();
             BlockPos newPosition = currentPosition.add(1, 0, 0); // Move one block forward
-            bot.teleport(newPosition.getX(), newPosition.getY(), newPosition.getZ());
+            bot.teleport(bot.getServerWorld(), newPosition.getX(), newPosition.getY(), newPosition.getZ(), Set.of(), bot.getYaw(), bot.getPitch());
 
             LOGGER.info("Teleported {} 1 positive block ahead", botName);
 

--- a/src/main/java/net/shasankp000/Entity/createFakePlayer.java
+++ b/src/main/java/net/shasankp000/Entity/createFakePlayer.java
@@ -29,6 +29,7 @@ import net.minecraft.util.UserCache;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.GameMode;
+import net.minecraft.world.TeleportTarget;
 import net.minecraft.world.World;
 
 import java.io.InputStreamReader;
@@ -188,10 +189,10 @@ public class createFakePlayer extends ServerPlayerEntity {
         shakeOff();
 
         if (reason.getContent() instanceof TranslatableTextContent text && text.getKey().equals("multiplayer.disconnect.duplicate_login")) {
-            this.networkHandler.onDisconnected(reason);
+            this.networkHandler.disconnect(reason);
         } else {
             this.server.send(new ServerTask(this.server.getTicks(), () -> {
-                this.networkHandler.onDisconnected(reason);
+                this.networkHandler.disconnect(reason);
             }));
         }
     }
@@ -254,9 +255,9 @@ public class createFakePlayer extends ServerPlayerEntity {
     }
 
     @Override
-    public Entity moveToWorld(ServerWorld serverLevel)
+    public Entity teleportTo(TeleportTarget target)
     {
-        super.moveToWorld(serverLevel);
+        Entity entity = super.teleportTo(target);
         if (notInAnyWorld) {
             ClientStatusC2SPacket p = new ClientStatusC2SPacket(ClientStatusC2SPacket.Mode.PERFORM_RESPAWN);
             networkHandler.onClientStatus(p);

--- a/src/main/java/net/shasankp000/Network/OpenConfigPayload.java
+++ b/src/main/java/net/shasankp000/Network/OpenConfigPayload.java
@@ -6,7 +6,7 @@ import net.minecraft.network.packet.CustomPayload;
 import net.minecraft.util.Identifier;
 
 public record OpenConfigPayload(String configData) implements CustomPayload {
-    public static final Identifier ID_IDENTIFIER = new Identifier("ai-player", "open_config");
+    public static final Identifier ID_IDENTIFIER = Identifier.of("ai-player", "open_config");
     public static final CustomPayload.Id<OpenConfigPayload> ID = new CustomPayload.Id<>(ID_IDENTIFIER);
 
     // Define a string codec with a max length (adjust 32767 as needed)

--- a/src/main/java/net/shasankp000/Network/SaveAPIKeyPayload.java
+++ b/src/main/java/net/shasankp000/Network/SaveAPIKeyPayload.java
@@ -7,7 +7,7 @@ import net.minecraft.network.packet.CustomPayload;
 import net.minecraft.util.Identifier;
 
 public record SaveAPIKeyPayload(String provider, String key) implements CustomPayload {
-    public static final Identifier ID_IDENTIFIER = new Identifier("ai-player", "save_api_key");
+    public static final Identifier ID_IDENTIFIER = Identifier.of("ai-player", "save_api_key");
     public static final CustomPayload.Id<SaveAPIKeyPayload> ID = new CustomPayload.Id<>(ID_IDENTIFIER);
 
 

--- a/src/main/java/net/shasankp000/Network/SaveConfigPayload.java
+++ b/src/main/java/net/shasankp000/Network/SaveConfigPayload.java
@@ -7,7 +7,7 @@ import net.minecraft.util.Identifier;
 
 
 public record SaveConfigPayload(String configData) implements CustomPayload {
-    public static final Identifier ID_IDENTIFIER = new Identifier("ai-player", "save_config");
+    public static final Identifier ID_IDENTIFIER = Identifier.of("ai-player", "save_config");
     public static final CustomPayload.Id<SaveConfigPayload> ID = new CustomPayload.Id<>(ID_IDENTIFIER);
 
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,13 +30,13 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.16.10",
-		"minecraft": "~1.20.6",
+		"minecraft": "~1.21.1",
 		"java": ">=21",
 		"fabric-api": "*"
 	},
 	"suggests": {
-		"carpet": "1.4.141",
-		"owo-lib": "0.12.9+1.20.5"
+		"carpet": "1.4.147",
+		"owo-lib": "0.12.15.4+1.21"
 	}
 
 }


### PR DESCRIPTION
A simple port of AI Player from Fabric 1.20.6 to Fabric 1.21.1.

### Read before merging
This port from 1.20.6 to 1.21.1 wasn't tested with ollama as I don't use/install that. So I do recommend testing this if you spot something that's broken in this port.

1.21.1 AI Player Screenshot.
<img width="1920" height="1017" alt="1.21.1 AI Player Commands Test" src="https://github.com/user-attachments/assets/b3261b6e-2697-480a-bae2-21e1a045c518" />
