### PR TITLE
Added handling for JSON array response from Generic OpenAI API

### DIFF
--- a/src/main/java/net/shasankp000/ServiceLLMClients/GenericOpenAIModelFetcher.java
+++ b/src/main/java/net/shasankp000/ServiceLLMClients/GenericOpenAIModelFetcher.java
@@ -55,9 +55,14 @@ public class GenericOpenAIModelFetcher implements ModelFetcher {
                 LOGGER.info("Request url: {}", request.uri());
                 LOGGER.info("Response code: {}", response.statusCode());
 
+                JsonElement jsonElement = JsonParser.parseString(response.body());
+                JsonArray models;
 
-                JsonObject jsonResponse = JsonParser.parseString(response.body()).getAsJsonObject();
-                JsonArray models = jsonResponse.getAsJsonArray("data");
+                if (jsonElement.isJsonArray()) {
+                    models = jsonElement.getAsJsonArray();
+                } else {
+                    models = jsonElement.getAsJsonObject().getAsJsonArray("data");
+                }
 
                 for (JsonElement modelElement : models) {
                     JsonObject modelObject = modelElement.getAsJsonObject();


### PR DESCRIPTION
Some providers return a JSON array of models instead of a JSON object with "data" field. I added a check to handle both formats and prevent "Not a JSON Object" crash