### PR TITLE
Replace Deprecated Code (AI Player 1.0.6.1 for Minecraft 26.2)

### DIFF
--- a/src/main/java/net/shasankp000/ChatUtils/Helper/JsonUtils.java
+++ b/src/main/java/net/shasankp000/ChatUtils/Helper/JsonUtils.java
@@ -2,6 +2,7 @@ package net.shasankp000.ChatUtils.Helper;
 
 import com.google.gson.JsonParser;
 import com.google.gson.JsonSyntaxException;
+import com.google.gson.Strictness;
 import com.google.gson.stream.JsonReader;
 
 import java.io.StringReader;
@@ -65,7 +66,7 @@ public class JsonUtils {
     private static boolean isValidJson(String jsonString) {
         try {
             JsonReader reader = new JsonReader(new StringReader(jsonString));
-            reader.setLenient(true);
+            reader.setStrictness(Strictness.LENIENT);
             JsonParser.parseReader(reader).getAsJsonObject();
             return true;
         } catch (JsonSyntaxException | IllegalStateException e) {

--- a/src/main/java/net/shasankp000/ChatUtils/NLPProcessor.java
+++ b/src/main/java/net/shasankp000/ChatUtils/NLPProcessor.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -95,7 +96,7 @@ public class NLPProcessor {
                 net.shasankp000.Overlay.NLPDownloadProgressManager.updateProgress("Downloading BERT NLP model...", currentStepNum);
                 LOGGER.info("📥 BERT NLP model not found — downloading for first-time setup...");
 
-                try (InputStream in = new URL(bertModelURL).openStream()) {
+                try (InputStream in = URI.create(bertModelURL).toURL().openStream()) {
                     Files.copy(in, torchZipFile, StandardCopyOption.REPLACE_EXISTING);
                 }
 
@@ -112,7 +113,7 @@ public class NLPProcessor {
 
                         Files.deleteIfExists(torchZipFile);
 
-                        try (InputStream in = new URL(bertModelURL).openStream()) {
+                        try (InputStream in = URI.create(bertModelURL).toURL().openStream()) {
                             Files.copy(in, torchZipFile, StandardCopyOption.REPLACE_EXISTING);
                         }
 
@@ -154,7 +155,7 @@ public class NLPProcessor {
                 net.shasankp000.Overlay.NLPDownloadProgressManager.updateProgress("Downloading CART NLP model...", currentStepNum);
                 LOGGER.info("📥 CART NLP model not found — downloading for first-time setup...");
 
-                try (InputStream in = new URL(cartZipURL).openStream()) {
+                try (InputStream in = URI.create(cartZipURL).toURL().openStream()) {
                     Files.copy(in, cartZipFile, StandardCopyOption.REPLACE_EXISTING);
                 }
 
@@ -174,7 +175,7 @@ public class NLPProcessor {
 
                         Files.deleteIfExists(cartZipFile);
 
-                        try (InputStream in = new URL(cartZipURL).openStream()) {
+                        try (InputStream in = URI.create(cartZipURL).toURL().openStream()) {
                             Files.copy(in, cartZipFile, StandardCopyOption.REPLACE_EXISTING);
                         }
 
@@ -214,7 +215,7 @@ public class NLPProcessor {
                     String expectedSha512 = entry.getValue();
 
                     try {
-                        URL url = new URL(modelURL);
+                        URL url = URI.create(modelURL).toURL();
                         String fileName = Paths.get(url.getPath()).getFileName().toString();
 
                         Path targetFilePath = openNlpModelsDir.resolve(fileName);
@@ -249,7 +250,7 @@ public class NLPProcessor {
                 net.shasankp000.Overlay.NLPDownloadProgressManager.updateProgress("Downloading LIDSNet model...", currentStepNum);
                 LOGGER.info("📥 LIDSNet NLP model not found — downloading for first-time setup...");
 
-                try (InputStream in = new URL(LIDSNetModelURL).openStream()) {
+                try (InputStream in = URI.create(LIDSNetModelURL).toURL().openStream()) {
                     Files.copy(in, LidsNETZipFile, StandardCopyOption.REPLACE_EXISTING);
                 }
 
@@ -266,7 +267,7 @@ public class NLPProcessor {
 
                         Files.deleteIfExists(LidsNETZipFile);
 
-                        try (InputStream in = new URL(LIDSNetModelURL).openStream()) {
+                        try (InputStream in = URI.create(LIDSNetModelURL).toURL().openStream()) {
                             Files.copy(in, LidsNETZipFile, StandardCopyOption.REPLACE_EXISTING);
                         }
 

--- a/src/main/java/net/shasankp000/ChatUtils/PreProcessing/NLPModelSetup.java
+++ b/src/main/java/net/shasankp000/ChatUtils/PreProcessing/NLPModelSetup.java
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -23,7 +23,7 @@ public class NLPModelSetup {
 
         while (retryCount <= MAX_RETRIES) {
             // Download
-            try (InputStream in = new URL(modelURL).openStream()) {
+            try (InputStream in = URI.create(modelURL).toURL().openStream()) {
                 Files.copy(in, targetFile, StandardCopyOption.REPLACE_EXISTING);
             }
 

--- a/src/main/java/net/shasankp000/Entity/createFakePlayer.java
+++ b/src/main/java/net/shasankp000/Entity/createFakePlayer.java
@@ -32,6 +32,7 @@ import net.minecraft.world.level.portal.TeleportTransition;
 import net.minecraft.world.phys.Vec3;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.URI;
 import java.net.URL;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -135,7 +136,7 @@ public class createFakePlayer extends ServerPlayer {
     private static CompletableFuture<Optional<GameProfile>> fetchGameProfile(final String name) {
         return CompletableFuture.supplyAsync(() -> {
             try {
-                URL url = new URL("https://api.mojang.com/users/profiles/minecraft/" + name);
+                URL url = URI.create("https://api.mojang.com/users/profiles/minecraft/" + name).toURL();
                 HttpURLConnection connection = (HttpURLConnection) url.openConnection();
                 connection.setRequestMethod("GET");
 

--- a/src/main/java/net/shasankp000/FunctionCaller/FunctionCallerV2.java
+++ b/src/main/java/net/shasankp000/FunctionCaller/FunctionCallerV2.java
@@ -1061,7 +1061,7 @@ public class FunctionCallerV2 {
                 String cleanedResponse = cleanJsonString(response);
                 logger.info("Cleaned JSON Response: {}", cleanedResponse);
                 JsonReader reader = new JsonReader(new StringReader(cleanedResponse));
-                reader.setLenient(true);
+                reader.setStrictness(Strictness.LENIENT);
                 JsonObject jsonObject = JsonParser.parseReader(reader).getAsJsonObject();
                 if (jsonObject.has("pipeline")) {
                     AutoFaceEntity.setBotExecutingTask(true);
@@ -1107,7 +1107,7 @@ public class FunctionCallerV2 {
                 String cleanedResponse = cleanJsonString(response);
                 logger.info("Cleaned JSON Response: {}", cleanedResponse);
                 JsonReader reader = new JsonReader(new StringReader(cleanedResponse));
-                reader.setLenient(true);
+                reader.setStrictness(Strictness.LENIENT);
                 JsonObject jsonObject = JsonParser.parseReader(reader).getAsJsonObject();
                 if (jsonObject.has("pipeline")) {
                     AutoFaceEntity.setBotExecutingTask(true);

--- a/src/main/java/net/shasankp000/GameAI/autonomous/NearbyBedSleepController.java
+++ b/src/main/java/net/shasankp000/GameAI/autonomous/NearbyBedSleepController.java
@@ -181,7 +181,7 @@ public final class NearbyBedSleepController {
                     if (distanceSquared > SEARCH_RADIUS_SQUARED) continue;
 
                     BlockPos pos = origin.offset(dx, dy, dz);
-                    if (level.isOutsideBuildHeight(pos) || !level.hasChunkAt(pos)) continue;
+                    if (level.isOutsideBuildHeight(pos) || !level.hasChunk(pos.getX() >> 4, pos.getZ() >> 4)) continue;
 
                     BlockState state = level.getBlockState(pos);
                     BlockPos footPos = state.getBlock() instanceof BedBlock
@@ -357,7 +357,7 @@ public final class NearbyBedSleepController {
 
     private static boolean validBedCell(ServerLevel level, BlockPos pos) {
         return level.isInsideBuildHeight(pos)
-                && level.hasChunkAt(pos)
+                && level.hasChunk(pos.getX() >> 4, pos.getZ() >> 4)
                 && level.getBlockState(pos).canBeReplaced();
     }
 


### PR DESCRIPTION
Also contains the deprecated code changes that were added from the [1.21.8 pull request](https://github.com/shasankp000/AI-Player/pull/59).

This is mainly just a 1.21.8 parity Pull Request to these fixes over to the 26.2 Branch.

This will mostly ensure that AI Player still works on newer versions of Minecraft & Fabric and avoids the code that I had replaced it with from getting removed later on.

**UNRELATED TO PULL REQUEST BELOW**
Also good news a Backport of AI Player 1.0.6 is coming to "Minecraft 26.1.2 - Tiny Takeover", because another one of the stable modding versions and it's one of the easiest to Backport!
edit: easiest Backport surprisingly, anyways, 26.1.2 was popular so there you go, it exists now!