### PR TITLE
Fix lead trajectory calculation, thread safety, and runtime exceptions

### DIFF
--- a/src/main/java/net/shasankp000/ChatUtils/DecisionResolver/DecisionResolver.java
+++ b/src/main/java/net/shasankp000/ChatUtils/DecisionResolver/DecisionResolver.java
@@ -94,6 +94,9 @@ public class DecisionResolver {
 
 
     public static String processLLMOutput(String fullResponse) {
+        if (fullResponse == null || fullResponse.isBlank()) {
+            return "No response!";
+        }
         Matcher matcher = THINK_BLOCK.matcher(fullResponse);
 
         if (matcher.find()) {
@@ -109,12 +112,7 @@ public class DecisionResolver {
                 return "No response!";
             }
         } else {
-            if (fullResponse != null || !fullResponse.isEmpty()) {
-                return fullResponse;
-            }
-            else {
-                return "No response!";
-            }
+            return fullResponse.trim();
         }
     }
 

--- a/src/main/java/net/shasankp000/ChatUtils/Helper/JsonUtils.java
+++ b/src/main/java/net/shasankp000/ChatUtils/Helper/JsonUtils.java
@@ -51,7 +51,7 @@ public class JsonUtils {
 
         int counter = 0;
         while (matcher.find()) {
-            matcher.appendReplacement(sb, "\"parameterName\":\"" + matcher.group(1) + "\",\"parameterValue\":\"" + matcher.group(2) + "\"");
+            matcher.appendReplacement(sb, Matcher.quoteReplacement("\"parameterName\":\"" + matcher.group(1) + "\",\"parameterValue\":\"" + matcher.group(2) + "\""));
             counter++;
         }
         matcher.appendTail(sb);

--- a/src/main/java/net/shasankp000/Commands/modCommandRegistry.java
+++ b/src/main/java/net/shasankp000/Commands/modCommandRegistry.java
@@ -406,7 +406,7 @@ public class modCommandRegistry {
 
                                                     Vec3 aimPosition;
                                                     if (isMovingFast) {
-                                                        aimPosition = RangedWeaponUtils.calculateLeadPosition(target, projectileSpeed);
+                                                        aimPosition = RangedWeaponUtils.calculateLeadPosition(bot, target, projectileSpeed);
                                                         LOGGER.info("Applied lead compensation for fast-moving target");
                                                     } else {
                                                         aimPosition = target.position().add(0, target.getBbHeight() * 0.6, 0);
@@ -450,7 +450,7 @@ public class modCommandRegistry {
                                                         if (finalTarget.isAlive()) {
                                                             Vec3 finalAimPosition;
                                                             if (isMovingFast) {
-                                                                finalAimPosition = RangedWeaponUtils.calculateLeadPosition(finalTarget, finalProjectileSpeed);
+                                                                finalAimPosition = RangedWeaponUtils.calculateLeadPosition(bot, finalTarget, finalProjectileSpeed);
                                                             } else {
                                                                 finalAimPosition = finalTarget.position().add(0, finalTarget.getBbHeight() * 0.6, 0);
                                                             }

--- a/src/main/java/net/shasankp000/Commands/modCommandRegistry.java
+++ b/src/main/java/net/shasankp000/Commands/modCommandRegistry.java
@@ -893,9 +893,9 @@ public class modCommandRegistry {
 
                                     ChatUtils.sendSystemMessage(serverSource, "Exporting Q-table to JSON. Please wait.... ");
 
-                                    QTableExporter.exportQTable(BotEventHandler.qTableDir + "/qtable.bin", BotEventHandler.qTableDir + "./fullQTable.json");
+                                    QTableExporter.exportQTable(BotEventHandler.qTableDir + "/qtable.bin", BotEventHandler.qTableDir + "/fullQTable.json");
 
-                                    ChatUtils.sendSystemMessage(serverSource, "Q-table has been successfully exported to a json file at: " + BotEventHandler.qTableDir + "./fullQTable.json" );
+                                    ChatUtils.sendSystemMessage(serverSource, "Q-table has been successfully exported to a json file at: " + BotEventHandler.qTableDir + "/fullQTable.json" );
 
                                     return 1;
                                 })

--- a/src/main/java/net/shasankp000/Database/SQLiteDB.java
+++ b/src/main/java/net/shasankp000/Database/SQLiteDB.java
@@ -168,6 +168,9 @@ public class SQLiteDB {
     }
 
     private static String vectorToLiteral(List<Double> vec) {
+        if (vec == null || vec.isEmpty()) {
+            return "[]";
+        }
         StringBuilder sb = new StringBuilder("[");
         for (int i = 0; i < vec.size(); i++) {
             sb.append(vec.get(i));

--- a/src/main/java/net/shasankp000/Entity/AutoFaceEntity.java
+++ b/src/main/java/net/shasankp000/Entity/AutoFaceEntity.java
@@ -449,22 +449,16 @@ public class AutoFaceEntity {
 
                     double distanceToHostileEntity = 0.0;
 
-                    try {
-
-                        // Find the closest hostile entity
+                    if (hostileEntities != null && !hostileEntities.isEmpty()) {
                         Entity closestHostile = hostileEntities.stream()
                                 .min(Comparator.comparingDouble(e -> e.distanceToSqr(bot.position())))
-                                .orElseThrow(); // Use orElseThrow since empty case is already handled
+                                .orElse(null);
 
-                        distanceToHostileEntity = Math.sqrt(closestHostile.distanceToSqr(bot.position()));
-
-                        // Log details of the detected hostile entity
-                        System.out.println("Closest hostile entity: " + closestHostile.getName().getString()
-                                + " at distance: " + distanceToHostileEntity);
-
-                    } catch (Exception e) {
-                        System.out.println("An exception occurred while calculating detecting hostile entities nearby" + e.getMessage());
-                        System.out.println(e.getStackTrace());
+                        if (closestHostile != null) {
+                            distanceToHostileEntity = Math.sqrt(closestHostile.distanceToSqr(bot.position()));
+                            System.out.println("Closest hostile entity: " + closestHostile.getName().getString()
+                                    + " at distance: " + distanceToHostileEntity);
+                        }
                     }
 
                     // first check if bot is moving, and if so, then stop moving.

--- a/src/main/java/net/shasankp000/GameAI/planner/Planner.java
+++ b/src/main/java/net/shasankp000/GameAI/planner/Planner.java
@@ -96,7 +96,7 @@ public class Planner {
         drafts.sort(Comparator.comparingDouble(sp -> sp.score));
 
         ScoredPlan bestDraft = drafts.get(0);
-        LOGGER.info("Generated {} drafts, best score: %.2f", drafts.size(), bestDraft.score);
+        LOGGER.info("Generated {} drafts, best score: {}", drafts.size(), String.format("%.2f", bestDraft.score));
 
         // Log best draft's actions for debugging
         if (LOGGER.isDebugEnabled() && !bestDraft.steps.isEmpty()) {
@@ -140,7 +140,7 @@ public class Planner {
             // Check for improvement
             if (beam.get(0).score < bestPlan.score) {
                 bestPlan = beam.get(0);
-                LOGGER.debug("Improved plan score: %.2f", bestPlan.score);
+                LOGGER.debug("Improved plan score: {}", String.format("%.2f", bestPlan.score));
             }
 
             // Early stop if safe enough
@@ -151,7 +151,7 @@ public class Planner {
         }
 
         long duration = System.currentTimeMillis() - startTime;
-        LOGGER.info("Planning completed in {}ms, final score: %.2f", duration, bestPlan.score);
+        LOGGER.info("Planning completed in {}ms, final score: {}", duration, String.format("%.2f", bestPlan.score));
 
         // Create final plan object
         if (bestPlan.score < 200.0) { // Reject plans that are too risky
@@ -167,7 +167,7 @@ public class Planner {
 
             return plan;
         } else {
-            LOGGER.warn("Best plan score too high (%.2f), rejecting", bestPlan.score);
+            LOGGER.warn("Best plan score too high ({}), rejecting", String.format("%.2f", bestPlan.score));
             return null;
         }
     }

--- a/src/main/java/net/shasankp000/PlayerUtils/MiningTool.java
+++ b/src/main/java/net/shasankp000/PlayerUtils/MiningTool.java
@@ -35,18 +35,27 @@ public class MiningTool {
                 ScheduledFuture<?> task = miningExecutor.scheduleAtFixedRate(() -> {
                     if (FoodConsumptionTool.isConsumptionInProgress(bot.getUUID())) return;
 
-                    BlockState currentState = bot.level().getBlockState(targetBlockPos);
-
-                    if (currentState.isAir()) {
-                        System.out.println("✅ Mining complete!");
-                        miningResult.complete("Mining complete!");
+                    MinecraftServer server = bot.getServer();
+                    if (server == null) {
+                        miningResult.complete("⚠️ Server not found");
                         miningExecutor.shutdownNow();
                         return;
                     }
 
-                    bot.swing(bot.getUsedItemHand());
-                    bot.gameMode.destroyBlock(targetBlockPos);
-                    System.out.println("⛏️ Mining...");
+                    server.execute(() -> {
+                        BlockState currentState = bot.level().getBlockState(targetBlockPos);
+
+                        if (currentState.isAir()) {
+                            System.out.println("✅ Mining complete!");
+                            miningResult.complete("Mining complete!");
+                            miningExecutor.shutdownNow();
+                            return;
+                        }
+
+                        bot.swing(bot.getUsedItemHand());
+                        bot.gameMode.destroyBlock(targetBlockPos);
+                        System.out.println("⛏️ Mining...");
+                    });
 
                 }, 0, ATTACK_INTERVAL_MS, TimeUnit.MILLISECONDS);
 

--- a/src/main/java/net/shasankp000/PlayerUtils/RangedWeaponUtils.java
+++ b/src/main/java/net/shasankp000/PlayerUtils/RangedWeaponUtils.java
@@ -457,12 +457,12 @@ public class RangedWeaponUtils {
     /**
      * Calculate lead compensation for moving targets
      */
-    public static Vec3 calculateLeadPosition(Entity target, double projectileSpeed) {
+    public static Vec3 calculateLeadPosition(ServerPlayer bot, Entity target, double projectileSpeed) {
         if (!(target instanceof LivingEntity)) {
             return target.position();
         }
 
-        Vec3 targetPos = target.position();
+        Vec3 targetPos = target.position().add(0, target.getBbHeight() * 0.6, 0);
         Vec3 targetVelocity = target.getDeltaMovement();
 
         // If target is not moving much, no need to lead
@@ -472,13 +472,20 @@ public class RangedWeaponUtils {
 
         // Calculate time for projectile to reach target (simplified)
         // Actual calculation would need to solve quadratic equation
-        double distance = targetPos.distanceTo(targetPos);
+        double distance = bot.position().distanceTo(target.position());
         double timeToImpact = distance / projectileSpeed;
 
         // Lead the target based on its velocity
         Vec3 leadOffset = targetVelocity.scale(timeToImpact * 0.8); // 0.8 factor for tuning
 
         return targetPos.add(leadOffset);
+    }
+
+    public static Vec3 calculateLeadPosition(Entity target, double projectileSpeed) {
+        if (!(target instanceof LivingEntity)) {
+            return target.position();
+        }
+        return target.position().add(0, target.getBbHeight() * 0.6, 0);
     }
 
     /**

--- a/src/main/java/net/shasankp000/WebSearch/WebSearchTool.java
+++ b/src/main/java/net/shasankp000/WebSearch/WebSearchTool.java
@@ -221,17 +221,10 @@ public class WebSearchTool {
                 "Return only one properly drafted query for the user prompt.\n";
 
 
-        List<Map<String, String>> queryConvo = new ArrayList<>();
-        Map<String, String> queryMap1 = new HashMap<>();
-
-        queryMap1.put("role", "system");
-        queryMap1.put("content", query_msg);
-
-        queryConvo.add(queryMap1);
         String response = "";
 
         if (client.isReachable()) {
-            response = client.sendPrompt(queryConvo.toString(), prompt);
+            response = client.sendPrompt(query_msg, prompt);
         }
         else {
             logger.warn("{} is not reachable; cannot generate a web search query.", client.getProvider());


### PR DESCRIPTION
- **Fixed projectile lead calculation (`RangedWeaponUtils.java`, `modCommandRegistry.java`):** I updated `calculateLeadPosition` to compute the Euclidean distance from the shooter (`bot.position()`) to the target instead of calling `targetPos.distanceTo(targetPos)`. Computing the distance between a coordinate and itself always returned `0.0`, which zeroed out `timeToImpact` and prevented the bot from ever leading moving targets with bows or crossbows.
- **Fixed null safety and inverted conditional in decision resolution (`DecisionResolver.java`):** I added a top-level null check before passing `fullResponse` into regex matching and replaced `fullResponse != null || !fullResponse.isEmpty()` with `fullResponse.trim()`. The original short-circuit OR evaluated `!fullResponse.isEmpty()` on null inputs (throwing a `NullPointerException`), and evaluated to `true` for empty strings `""`, returning an empty string instead of `"No response!"`.
- **Eliminated guaranteed `NoSuchElementException` in tick loop (`AutoFaceEntity.java`):** In the danger zone and sculk detection branch, I guarded the stream operations with `if (hostileEntities != null && !hostileEntities.isEmpty())`. Because this `else if` branch only executes when `!hostileEntities.isEmpty()` is false, calling `orElseThrow()` on an empty stream unconditionally threw `NoSuchElementException` every 33ms tick, causing heavy stack trace allocations.
- **Fixed regex replacement crash with placeholder tokens (`JsonUtils.java`):** I wrapped the replacement string in `Matcher.quoteReplacement()` inside `getStringBuffer`. When JSON parameters contained state placeholders starting with `$` (such as `"$lastDetectedBlock.x"`), `Matcher.appendReplacement()` treated the dollar sign as a regex group reference and threw an `IllegalArgumentException`.
- **Protected vector serialization against null values (`SQLiteDB.java`):** I added a null and empty check to `vectorToLiteral` to return `"[]"` when `vec == null`. If an upstream embedding provider fails or returns null, calling `vec.size()` previously threw an unhandled `NullPointerException` during database insertion.
- **Fixed malformed export file path (`modCommandRegistry.java`):** I corrected the string concatenation in the `/bot exportQTableToJSON` command from `BotEventHandler.qTableDir + "./fullQTable.json"` to `BotEventHandler.qTableDir + "/fullQTable.json"`. The original concatenation produced an invalid path (`.../qtable_storage./fullQTable.json`), breaking file output.
- **Fixed SLF4J logger format specifiers (`Planner.java`):** I replaced `printf`-style `%.2f` specifiers with `{}` placeholders combined with `String.format()`. SLF4J does not parse `printf` tokens natively, which caused the literal string `%.2f` to be logged while the numeric score parameters were discarded.
- **Resolved cross-thread world modification race condition (`MiningTool.java`):** I wrapped block destruction (`bot.gameMode.destroyBlock`) and swing animations (`bot.swing`) inside `server.execute()`. These methods were previously invoked directly on a background `ScheduledExecutorService` thread, causing thread-safety violations against Minecraft's server tick loop and chunk management.
- **Fixed LLM system prompt formatting in web query generation (`WebSearchTool.java`):** In the overloaded `createQuery(String, LLMClient)` method, I changed `client.sendPrompt(queryConvo.toString(), prompt)` to pass `query_msg` directly. The previous implementation passed Java's raw `ArrayList.toString()` representation (`[{role=system, content=...}]`) as the system prompt string to the LLM.