### PR TITLE
Add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+
+      - name: Build JAR
+        run: ./gradlew build --no-daemon


### PR DESCRIPTION
I added a GitHub Actions workflow that builds the project but doesn’t upload or publish anything, so we can only see whether it passes or fails. I personally like having a GitHub workflow so we can easily see if everything works, but if you don’t want it, just let me know and I’ll close this PR. As you can see, it currently fails because of `MiningTool` and `MinecraftServer`. So what do you think @shasankp000 
