### PR TITLE
Fix custom provider models not appearing in config UI

### DIFF
--- a/src/main/java/net/shasankp000/AIPlayerClient.java
+++ b/src/main/java/net/shasankp000/AIPlayerClient.java
@@ -15,7 +15,6 @@ import net.shasankp000.ChatUtils.ChatContextManager;
 import net.shasankp000.ChatUtils.ChatUtils;
 import net.shasankp000.ChatUtils.ClarificationState;
 import net.shasankp000.FilingSystem.LLMClientFactory;
-import net.shasankp000.FilingSystem.ManualConfig;
 import net.shasankp000.LauncherDetection.LauncherEnvironment;
 import net.shasankp000.Network.OpenConfigPayload;
 import net.shasankp000.ServiceLLMClients.*;
@@ -34,7 +33,6 @@ public class AIPlayerClient implements ClientModInitializer {
     private static final Path BOT_PROFILE_PATH = Paths.get(LauncherEnvironment.getStorageDirectory("config") + File.separator + "settings.json5");
     private static JsonObject botProfiles;
     public static final Logger LOGGER = LoggerFactory.getLogger("ai-player-client");
-    public static final ManualConfig CONFIG = ManualConfig.load();
 
 
     static {

--- a/src/main/java/net/shasankp000/FilingSystem/ManualConfig.java
+++ b/src/main/java/net/shasankp000/FilingSystem/ManualConfig.java
@@ -82,9 +82,10 @@ public class ManualConfig {
      * Asynchronously updates the list of available models based on the selected provider.
      * This method fetches the model list and then saves the updated configuration to the file.
      */
-    public void updateModels() {
-        // Run the network operation on a separate thread to prevent freezing.
-        CompletableFuture.runAsync(() -> {
+    public CompletableFuture<List<String>> updateModels() {
+        // Return the future so callers can update their state only after the
+        // network operation has finished.
+        return CompletableFuture.supplyAsync(() -> {
             try {
                 List<String> fetchedModels = new ArrayList<>();
                 ModelFetcher modelFetcher = null;
@@ -104,7 +105,7 @@ public class ManualConfig {
 
                         this.modelList = fetchedModels;
                         this.save();
-                        return;
+                        return new ArrayList<>(this.modelList);
                     case "openai":
                         modelFetcher = new OpenAIModelFetcher();
                         apiKey = this.openAIKey;
@@ -127,12 +128,12 @@ public class ManualConfig {
                             apiKey = this.customApiKey;
                         } else {
                             LOGGER.error("Custom provider selected but no API URL configured");
-                            return;
+                            return new ArrayList<>(this.modelList);
                         }
                         break;
                     default:
                         LOGGER.error("Unsupported provider: {}", llmMode);
-                        return;
+                        return new ArrayList<>(this.modelList);
                 }
 
                 if (llmMode.equals("ollama")) {
@@ -173,6 +174,7 @@ public class ManualConfig {
                 this.save();
             }
 
+            return new ArrayList<>(this.modelList);
         });
     }
 

--- a/src/main/java/net/shasankp000/GraphicalUserInterface/ConfigManager.java
+++ b/src/main/java/net/shasankp000/GraphicalUserInterface/ConfigManager.java
@@ -1,7 +1,5 @@
 package net.shasankp000.GraphicalUserInterface;
 
-import net.fabricmc.api.EnvType;
-import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.EditBox;
@@ -9,7 +7,6 @@ import net.minecraft.client.gui.components.toasts.SystemToast;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
 import net.shasankp000.AIPlayer;
-import net.shasankp000.AIPlayerClient;
 import net.shasankp000.GraphicalUserInterface.Widgets.DropdownMenuWidget;
 import net.shasankp000.Network.configNetworkManager;
 import org.slf4j.Logger;
@@ -35,20 +32,10 @@ public class ConfigManager extends Screen {
 
     @Override
     protected void init() {
-        // added this line so that the models will load immediately after the API key has been entered and saved into the json.
-        LOGGER.info("Refreshing model list from provider...");
-        AIPlayer.CONFIG.updateModels();
-
-        if (FabricLoader.getInstance().getEnvironmentType().equals(EnvType.CLIENT)) {
-            AIPlayerClient.CONFIG.updateModels();
-        }
-
-        if (FabricLoader.getInstance().getEnvironmentType().equals(EnvType.CLIENT)) {
-            allModels = AIPlayerClient.CONFIG.getModelList();
-        } else {
-            allModels = AIPlayer.CONFIG.getModelList();
-        }
-        LOGGER.info("Fetched {} models from provider on frontend.", allModels.size());
+        // Show the cached list immediately, then replace it when the asynchronous
+        // provider refresh completes.
+        allModels = new ArrayList<>(AIPlayer.CONFIG.getModelList());
+        LOGGER.info("Loaded {} cached models on frontend.", allModels.size());
         filteredModels = new ArrayList<>(allModels);
 
         int centerX = this.width / 2;
@@ -89,6 +76,8 @@ public class ConfigManager extends Screen {
         this.addRenderableWidget(Button.builder(Component.nullToEmpty("Close"), (btn1) -> this.onClose()).bounds(buttonsStartX + buttonSpacing * 4, buttonY, buttonWidth, fieldHeight).build());
 
         this.addRenderableWidget(dropdownMenuWidget);
+
+        refreshModels(false);
     }
 
     @Override
@@ -127,20 +116,45 @@ public class ConfigManager extends Screen {
     }
 
     private void reloadModels() {
-        LOGGER.info("Reloading model list from provider...");
-        AIPlayer.CONFIG.updateModels();
-        if (FabricLoader.getInstance().getEnvironmentType().equals(EnvType.CLIENT)) {
-            AIPlayerClient.CONFIG.updateModels();
-            allModels = AIPlayerClient.CONFIG.getModelList();
-        } else {
-            allModels = AIPlayer.CONFIG.getModelList();
-        }
-        filteredModels = new ArrayList<>(allModels);
-        dropdownMenuWidget.updateOptions(filteredModels);
-        
-        if (this.minecraft != null) {
-            this.minecraft.gui.toastManager().addToast(new SystemToast(SystemToast.SystemToastId.NARRATOR_TOGGLE, Component.nullToEmpty("Models Reloaded"), Component.nullToEmpty("Found " + allModels.size() + " models")));
-        }
+        refreshModels(true);
+    }
+
+    private void refreshModels(boolean showToast) {
+        LOGGER.info("Refreshing model list from provider...");
+        AIPlayer.CONFIG.updateModels().whenComplete((models, error) -> {
+            if (this.minecraft == null) {
+                return;
+            }
+
+            this.minecraft.execute(() -> {
+                // Do not mutate widgets after the user has left this screen.
+                if (this.minecraft == null || this.minecraft.gui.screen() != this) {
+                    return;
+                }
+
+                if (error != null) {
+                    LOGGER.error("Failed to refresh model list", error);
+                    if (showToast) {
+                        this.minecraft.gui.toastManager().addToast(new SystemToast(
+                                SystemToast.SystemToastId.NARRATOR_TOGGLE,
+                                Component.nullToEmpty("Model Refresh Failed"),
+                                Component.nullToEmpty(error.getMessage())));
+                    }
+                    return;
+                }
+
+                allModels = models != null ? new ArrayList<>(models) : new ArrayList<>();
+                onSearchChanged(searchField.getValue());
+                LOGGER.info("Fetched {} models from provider on frontend.", allModels.size());
+
+                if (showToast) {
+                    this.minecraft.gui.toastManager().addToast(new SystemToast(
+                            SystemToast.SystemToastId.NARRATOR_TOGGLE,
+                            Component.nullToEmpty("Models Reloaded"),
+                            Component.nullToEmpty("Found " + allModels.size() + " models")));
+                }
+            });
+        });
     }
 
     private void saveToFile() {


### PR DESCRIPTION
## Summary

- use the single shared `AIPlayer.CONFIG` instance instead of loading a stale client-side duplicate
- return the asynchronous model-fetch result from `ManualConfig.updateModels()`
- update the model dropdown on the Minecraft render thread after fetching completes
- keep cached models visible while refreshing and avoid mutating widgets after leaving the screen

## Problem

The custom provider could successfully return models (`200` with a populated model list), while the configuration screen still showed zero models. `ConfigManager` started two asynchronous refreshes, immediately read `AIPlayerClient.CONFIG`, and populated the dropdown before either refresh completed. The successful fetch commonly updated `AIPlayer.CONFIG`, while the separately loaded client config remained stale and could report that no custom API URL was configured.

## Testing

- `./gradlew test --no-daemon`
- `./gradlew build --no-daemon`

Both complete successfully with Java 25.
