### PR TITLE
Add OpenAI Responses API support

### DIFF
--- a/CUSTOM_PROVIDERS.md
+++ b/CUSTOM_PROVIDERS.md
@@ -18,6 +18,8 @@ Set the system property when launching the game:
    - **Custom API URL**: The base URL of your provider (e.g., `https://openrouter.ai/api/v1`)
    - **Custom API Key**: Your API key for the provider
 
+AI-Player uses Chat Completions first for a base URL and automatically retries the Responses API when the provider or selected model does not support Chat Completions. To prefer the Responses API immediately, enter the full endpoint (for example, `https://api.openai.com/v1/responses`).
+
 ### 3. Select a Model
 
 The system will automatically fetch available models from your provider's `/models` endpoint and display them in the model selection interface.
@@ -37,9 +39,10 @@ Any provider that implements the OpenAI API standard should work. Some examples:
 The custom provider implementation uses the following OpenAI API endpoints:
 
 - `GET /models` - For fetching available models
-- `POST /chat/completions` - For sending chat completion requests
+- `POST /chat/completions` - For Chat Completions requests
+- `POST /responses` - For Responses API requests
 
-Your provider must support these endpoints with the same request/response format as OpenAI's API.
+The provider must implement `GET /models` and at least one of the two generation endpoints using the corresponding OpenAI request and response format. AI-Player automatically falls back between the generation endpoints for endpoint/model compatibility errors and remembers the working endpoint for that model.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ Set the system property(JVM argument) when launching the game:
 4. If you still don't see the list of models, close the config manager, type `/configMan` again and you should see the list of models available.
 5. Ollama is not required. AI Player connects directly to the configured provider endpoint.
 
+AI-Player uses Chat Completions first for a base URL and automatically retries the Responses API when the provider or selected model does not support Chat Completions. To prefer the Responses API immediately, enter the full endpoint (for example, `https://api.openai.com/v1/responses`).
+
 ### 3. Select a Model
 
 The system will automatically fetch available models from your provider's `/models` endpoint and display them in the model selection interface.
@@ -222,9 +224,10 @@ instead.
 The custom provider implementation uses the following OpenAI API endpoints:
 
 - `GET /models` - For fetching available models
-- `POST /chat/completions` - For sending chat completion requests
+- `POST /chat/completions` - For Chat Completions requests
+- `POST /responses` - For Responses API requests
 
-Your provider must support these endpoints with the same request/response format as OpenAI's API.
+The provider must implement `GET /models` and at least one of the two generation endpoints using the corresponding OpenAI request and response format. AI-Player automatically falls back between the generation endpoints for endpoint/model compatibility errors and remembers the working endpoint for that model.
 
 ## Troubleshooting
 

--- a/src/main/java/net/shasankp000/AIProviders/EmbeddingProvider.java
+++ b/src/main/java/net/shasankp000/AIProviders/EmbeddingProvider.java
@@ -72,6 +72,7 @@ public class EmbeddingProvider {
         String normalized = baseUrl.trim().replaceAll("/+$", "");
         normalized = normalized.replaceAll("/chat/completions$", "");
         normalized = normalized.replaceAll("/completions$", "");
+        normalized = normalized.replaceAll("/responses$", "");
         normalized = normalized.replaceAll("/embeddings$", "");
         if (normalized.endsWith("/v1")) {
             normalized = normalized.substring(0, normalized.length() - 3);

--- a/src/main/java/net/shasankp000/FilingSystem/EmbeddingClientFactory.java
+++ b/src/main/java/net/shasankp000/FilingSystem/EmbeddingClientFactory.java
@@ -162,9 +162,9 @@ public class EmbeddingClientFactory {
 
     /**
      * Intelligently derive embedding endpoint from base API URL.
-     * Handles common patterns like /v1/chat/completions, /chat/completions, etc.
+     * Handles common patterns like /v1/chat/completions, /v1/responses, etc.
      *
-     * @param baseUrl The base API URL (e.g., https://api.provider.com/v1/chat/completions)
+     * @param baseUrl The base API URL (e.g., https://api.provider.com/v1/responses)
      * @return The embedding endpoint URL (e.g., https://api.provider.com/v1/embeddings)
      */
     private static String deriveEmbeddingEndpoint(String baseUrl) {
@@ -179,6 +179,11 @@ public class EmbeddingClientFactory {
         // Pattern 2: URL ends with /completions -> replace with /embeddings
         if (normalizedUrl.matches(".*/(v1/)?completions$")) {
             return normalizedUrl.replaceAll("/completions$", "/embeddings");
+        }
+
+        // Responses API endpoint -> replace with /embeddings
+        if (normalizedUrl.matches(".*/(v1/)?responses$")) {
+            return normalizedUrl.replaceAll("/responses$", "/embeddings");
         }
 
         // Pattern 3: URL ends with /chat -> replace with /embeddings

--- a/src/main/java/net/shasankp000/ServiceLLMClients/GenericOpenAIClient.java
+++ b/src/main/java/net/shasankp000/ServiceLLMClients/GenericOpenAIClient.java
@@ -147,8 +147,14 @@ public class GenericOpenAIClient implements LLMClient {
     private JsonObject createResponsesRequest(String systemPrompt, String userPrompt) {
         JsonObject requestBody = new JsonObject();
         requestBody.addProperty("model", modelName);
-        requestBody.addProperty("instructions", systemPrompt);
-        requestBody.addProperty("input", userPrompt);
+
+        // Although OpenAI accepts a scalar input string, some compatible
+        // gateways (including LiteLLM ChatGPT routes) require a message list.
+        JsonArray input = new JsonArray();
+        input.add(createMessage("system", systemPrompt));
+        input.add(createMessage("user", userPrompt));
+
+        requestBody.add("input", input);
         requestBody.addProperty("max_output_tokens", MAX_OUTPUT_TOKENS);
         requestBody.addProperty("store", false);
         return requestBody;

--- a/src/main/java/net/shasankp000/ServiceLLMClients/GenericOpenAIClient.java
+++ b/src/main/java/net/shasankp000/ServiceLLMClients/GenericOpenAIClient.java
@@ -141,6 +141,7 @@ public class GenericOpenAIClient implements LLMClient {
 
         requestBody.add("messages", messages);
         requestBody.addProperty("max_tokens", MAX_OUTPUT_TOKENS);
+        requestBody.addProperty("stream", false);
         return requestBody;
     }
 
@@ -157,6 +158,7 @@ public class GenericOpenAIClient implements LLMClient {
         requestBody.add("input", input);
         requestBody.addProperty("max_output_tokens", MAX_OUTPUT_TOKENS);
         requestBody.addProperty("store", false);
+        requestBody.addProperty("stream", false);
         return requestBody;
     }
 
@@ -192,6 +194,11 @@ public class GenericOpenAIClient implements LLMClient {
 
     private static String extractResponseText(ApiEndpoint endpoint, String rawResponseBody) {
         try {
+            String trimmedBody = rawResponseBody.trim();
+            if (trimmedBody.startsWith("data:") || trimmedBody.startsWith("event:")) {
+                return extractEventStreamText(endpoint, rawResponseBody);
+            }
+
             JsonElement parsed = JsonParser.parseString(rawResponseBody);
             if (!parsed.isJsonObject()) {
                 return "Error: Provider returned an invalid JSON response.";
@@ -206,6 +213,95 @@ public class GenericOpenAIClient implements LLMClient {
             LOGGER.warn("Could not parse OpenAI-compatible response: {}", rawResponseBody, e);
             return "Error: Could not parse provider response.";
         }
+    }
+
+    private static String extractEventStreamText(ApiEndpoint endpoint, String rawResponseBody) {
+        StringBuilder deltas = new StringBuilder();
+        String completedText = "";
+
+        for (String line : rawResponseBody.split("\\R")) {
+            String trimmedLine = line.trim();
+            if (!trimmedLine.startsWith("data:")) {
+                continue;
+            }
+
+            String data = trimmedLine.substring("data:".length()).trim();
+            if (data.isEmpty() || data.equals("[DONE]")) {
+                continue;
+            }
+
+            try {
+                JsonElement parsedEvent = JsonParser.parseString(data);
+                if (!parsedEvent.isJsonObject()) {
+                    continue;
+                }
+
+                JsonObject event = parsedEvent.getAsJsonObject();
+                String eventType = readStringField(event, "type");
+                if (eventType.endsWith(".delta")) {
+                    appendText(deltas, readStringField(event, "delta"));
+                    continue;
+                }
+                if (eventType.endsWith(".done")) {
+                    String doneText = readStringField(event, "text");
+                    if (!doneText.isEmpty()) {
+                        completedText = doneText;
+                    }
+                    continue;
+                }
+
+                JsonArray choices = getArray(event, "choices");
+                if (choices != null) {
+                    for (JsonElement choiceElement : choices) {
+                        if (!choiceElement.isJsonObject()) {
+                            continue;
+                        }
+                        JsonObject choice = choiceElement.getAsJsonObject();
+                        JsonObject delta = getObject(choice, "delta");
+                        appendText(deltas, readContentField(delta, "content"));
+                    }
+                    continue;
+                }
+
+                JsonObject eventResponse = getObject(event, "response");
+                if (eventResponse != null) {
+                    // Lifecycle events such as response.created and
+                    // response.in_progress do not contain generated text.
+                    if (eventType.equals("response.completed")) {
+                        String extracted = extractResponsesText(eventResponse, data);
+                        if (!extracted.startsWith("Error:")) {
+                            completedText = extracted;
+                        }
+                    }
+                    continue;
+                }
+
+                // Other typed lifecycle events (output_item.added,
+                // content_part.added, etc.) carry metadata rather than text.
+                if (!eventType.isEmpty()) {
+                    continue;
+                }
+
+                String extracted = endpoint == ApiEndpoint.RESPONSES
+                        ? extractResponsesText(event, data)
+                        : extractChatCompletionsText(event, data);
+                if (!extracted.startsWith("Error:")) {
+                    completedText = extracted;
+                }
+            } catch (Exception e) {
+                LOGGER.debug("Ignoring malformed event-stream data: {}", data, e);
+            }
+        }
+
+        if (!deltas.isEmpty()) {
+            return deltas.toString();
+        }
+        if (!completedText.isEmpty()) {
+            return completedText;
+        }
+
+        LOGGER.warn("Provider returned an event stream without text output");
+        return "Error: Provider returned an empty event stream.";
     }
 
     private static String extractResponsesText(JsonObject jsonResponse, String rawResponseBody) {

--- a/src/main/java/net/shasankp000/ServiceLLMClients/GenericOpenAIClient.java
+++ b/src/main/java/net/shasankp000/ServiceLLMClients/GenericOpenAIClient.java
@@ -7,107 +7,271 @@ import com.google.gson.JsonParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Generic OpenAI-compatible client that supports custom API base URLs.
- * This allows using alternative providers like OpenRouter that follow the OpenAI API standard.
+ * Supports both Chat Completions and the newer Responses API.
  */
 public class GenericOpenAIClient implements LLMClient {
+    private static final int MAX_OUTPUT_TOKENS = 1024;
+    private static final Map<String, ApiEndpoint> API_PREFERENCES = new ConcurrentHashMap<>();
+
     private final String apiKey;
     private final String modelName;
     private final String baseUrl;
+    private final String preferenceKey;
     private final HttpClient client;
+    private volatile ApiEndpoint preferredEndpoint;
+
     public static final Logger LOGGER = LoggerFactory.getLogger("GenericOpenAI-Client");
 
     public GenericOpenAIClient(String apiKey, String modelName, String baseUrl) {
         this.apiKey = apiKey;
         this.modelName = modelName;
-        // Ensure baseUrl ends with "/" but doesn't have double slashes
+
         if (baseUrl == null || baseUrl.trim().isEmpty()) {
             throw new IllegalArgumentException("Base URL cannot be null or empty");
         }
+
+        ApiEndpoint configuredEndpoint = detectConfiguredEndpoint(baseUrl);
         this.baseUrl = normalizeBaseUrl(baseUrl);
+        String configuredMode = configuredEndpoint != null ? configuredEndpoint.name() : "AUTO";
+        String credentialScope = apiKey != null ? Integer.toHexString(apiKey.hashCode()) : "anonymous";
+        this.preferenceKey = this.baseUrl + "|" + this.modelName + "|" + configuredMode + "|" + credentialScope;
+        this.preferredEndpoint = API_PREFERENCES.getOrDefault(
+                this.preferenceKey,
+                configuredEndpoint != null ? configuredEndpoint : ApiEndpoint.CHAT_COMPLETIONS);
         this.client = HttpClient.newHttpClient();
+    }
+
+    private static ApiEndpoint detectConfiguredEndpoint(String baseUrl) {
+        String normalized = baseUrl.trim().replaceAll("/+$", "");
+        if (normalized.endsWith("/responses")) {
+            return ApiEndpoint.RESPONSES;
+        }
+        if (normalized.endsWith("/chat/completions") || normalized.endsWith("/completions")) {
+            return ApiEndpoint.CHAT_COMPLETIONS;
+        }
+        return null;
     }
 
     private static String normalizeBaseUrl(String baseUrl) {
         String normalized = baseUrl.trim().replaceAll("/+$", "");
         normalized = normalized.replaceAll("/chat/completions$", "");
         normalized = normalized.replaceAll("/completions$", "");
+        normalized = normalized.replaceAll("/responses$", "");
         normalized = normalized.replaceAll("/embeddings$", "");
         return normalized + "/";
     }
 
     @Override
     public String sendPrompt(String systemPrompt, String userPrompt) {
+        ApiEndpoint primaryEndpoint = preferredEndpoint;
         try {
-            // Construct the request body for chat completions
-            JsonObject requestBody = new JsonObject();
-            requestBody.addProperty("model", this.modelName);
-
-            JsonArray messages = new JsonArray();
-
-            // 1. Create the system message object and add it to the array
-            JsonObject systemMessage = new JsonObject();
-            systemMessage.addProperty("role", "system");
-            systemMessage.addProperty("content", systemPrompt);
-            messages.add(systemMessage);
-
-            // 2. Create the user message object and add it to the array
-            JsonObject userMessage = new JsonObject();
-            userMessage.addProperty("role", "user");
-            userMessage.addProperty("content", userPrompt);
-            messages.add(userMessage);
-
-            requestBody.add("messages", messages);
-            requestBody.addProperty("max_tokens", 1024);
-
-            HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-                    .uri(URI.create(baseUrl + "chat/completions"))
-                    .header("Content-Type", "application/json")
-                    .POST(BodyPublishers.ofString(requestBody.toString()));
-
-            if (apiKey != null && !apiKey.isBlank()) {
-                requestBuilder.header("Authorization", "Bearer " + apiKey);
+            ApiResponse primaryResponse = sendRequest(primaryEndpoint, systemPrompt, userPrompt);
+            if (primaryResponse.isSuccessful()) {
+                return extractResponseText(primaryEndpoint, primaryResponse.body());
             }
 
-            HttpRequest request = requestBuilder.build();
-
-            HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
-
-            // Handle HTTP error codes
-            if (response.statusCode() != 200) {
-                return "Error: " + response.statusCode() + " - " + response.body();
+            if (!shouldTryAlternateEndpoint(primaryResponse.statusCode())) {
+                return formatHttpError(primaryResponse);
             }
 
-            // Parse the JSON response
-            JsonObject jsonResponse = JsonParser.parseString(response.body()).getAsJsonObject();
+            ApiEndpoint alternateEndpoint = primaryEndpoint.alternate();
+            LOGGER.info("{} returned HTTP {} for model {}; trying {}",
+                    primaryEndpoint.displayName,
+                    primaryResponse.statusCode(),
+                    modelName,
+                    alternateEndpoint.displayName);
 
-            return extractResponseText(jsonResponse, response.body());
+            ApiResponse alternateResponse = sendRequest(alternateEndpoint, systemPrompt, userPrompt);
+            if (alternateResponse.isSuccessful()) {
+                preferredEndpoint = alternateEndpoint;
+                if (shouldRememberAlternateEndpoint(primaryResponse)) {
+                    API_PREFERENCES.put(preferenceKey, alternateEndpoint);
+                }
+                return extractResponseText(alternateEndpoint, alternateResponse.body());
+            }
 
+            return formatCombinedHttpError(primaryResponse, alternateResponse);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            LOGGER.error("Interrupted while sending prompt", e);
+            return "Error: Request interrupted";
         } catch (Exception e) {
             LOGGER.error("Error occurred while sending prompt", e);
             return "Error: " + e.getMessage();
         }
     }
 
-    private static String extractResponseText(JsonObject jsonResponse, String rawResponseBody) {
-        JsonArray choices = jsonResponse.getAsJsonArray("choices");
-        if (choices == null || choices.isEmpty()) {
+    private ApiResponse sendRequest(ApiEndpoint endpoint, String systemPrompt, String userPrompt)
+            throws IOException, InterruptedException {
+        JsonObject requestBody = endpoint == ApiEndpoint.RESPONSES
+                ? createResponsesRequest(systemPrompt, userPrompt)
+                : createChatCompletionsRequest(systemPrompt, userPrompt);
+
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl + endpoint.path))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody.toString()));
+
+        if (apiKey != null && !apiKey.isBlank()) {
+            requestBuilder.header("Authorization", "Bearer " + apiKey);
+        }
+
+        HttpResponse<String> response = client.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+        return new ApiResponse(endpoint, response.statusCode(), response.body());
+    }
+
+    private JsonObject createChatCompletionsRequest(String systemPrompt, String userPrompt) {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("model", modelName);
+
+        JsonArray messages = new JsonArray();
+        messages.add(createMessage("system", systemPrompt));
+        messages.add(createMessage("user", userPrompt));
+
+        requestBody.add("messages", messages);
+        requestBody.addProperty("max_tokens", MAX_OUTPUT_TOKENS);
+        return requestBody;
+    }
+
+    private JsonObject createResponsesRequest(String systemPrompt, String userPrompt) {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("model", modelName);
+        requestBody.addProperty("instructions", systemPrompt);
+        requestBody.addProperty("input", userPrompt);
+        requestBody.addProperty("max_output_tokens", MAX_OUTPUT_TOKENS);
+        requestBody.addProperty("store", false);
+        return requestBody;
+    }
+
+    private static JsonObject createMessage(String role, String content) {
+        JsonObject message = new JsonObject();
+        message.addProperty("role", role);
+        message.addProperty("content", content);
+        return message;
+    }
+
+    private static boolean shouldTryAlternateEndpoint(int statusCode) {
+        return switch (statusCode) {
+            case 400, 404, 405, 422, 501 -> true;
+            default -> false;
+        };
+    }
+
+    private static boolean shouldRememberAlternateEndpoint(ApiResponse failedResponse) {
+        if (failedResponse.statusCode() == 404
+                || failedResponse.statusCode() == 405
+                || failedResponse.statusCode() == 501) {
+            return true;
+        }
+
+        String body = failedResponse.body().toLowerCase(Locale.ROOT);
+        return body.contains("responses api")
+                || body.contains("/responses")
+                || body.contains("chat completions")
+                || body.contains("chat/completions")
+                || body.contains("unsupported endpoint")
+                || body.contains("endpoint is not supported");
+    }
+
+    private static String extractResponseText(ApiEndpoint endpoint, String rawResponseBody) {
+        try {
+            JsonElement parsed = JsonParser.parseString(rawResponseBody);
+            if (!parsed.isJsonObject()) {
+                return "Error: Provider returned an invalid JSON response.";
+            }
+
+            JsonObject jsonResponse = parsed.getAsJsonObject();
+            if (endpoint == ApiEndpoint.RESPONSES) {
+                return extractResponsesText(jsonResponse, rawResponseBody);
+            }
+            return extractChatCompletionsText(jsonResponse, rawResponseBody);
+        } catch (Exception e) {
+            LOGGER.warn("Could not parse OpenAI-compatible response: {}", rawResponseBody, e);
+            return "Error: Could not parse provider response.";
+        }
+    }
+
+    private static String extractResponsesText(JsonObject jsonResponse, String rawResponseBody) {
+        String topLevelOutputText = readStringField(jsonResponse, "output_text");
+        if (!topLevelOutputText.isBlank()) {
+            return topLevelOutputText;
+        }
+
+        StringBuilder text = new StringBuilder();
+        JsonArray output = getArray(jsonResponse, "output");
+        if (output != null) {
+            for (JsonElement outputElement : output) {
+                if (!outputElement.isJsonObject()) {
+                    continue;
+                }
+
+                JsonObject outputItem = outputElement.getAsJsonObject();
+                appendText(text, readStringField(outputItem, "text"));
+
+                JsonArray content = getArray(outputItem, "content");
+                if (content == null) {
+                    continue;
+                }
+
+                for (JsonElement contentElement : content) {
+                    if (!contentElement.isJsonObject()) {
+                        continue;
+                    }
+                    JsonObject contentItem = contentElement.getAsJsonObject();
+                    appendText(text, readStringField(contentItem, "text"));
+                    appendText(text, readStringField(contentItem, "refusal"));
+                }
+            }
+        }
+
+        if (!text.isEmpty()) {
+            return text.toString();
+        }
+
+        // Some compatible gateways return Chat Completions-shaped data from
+        // their Responses endpoint. Accept it rather than rejecting useful text.
+        if (jsonResponse.has("choices")) {
+            return extractChatCompletionsText(jsonResponse, rawResponseBody);
+        }
+
+        JsonObject error = getObject(jsonResponse, "error");
+        String errorMessage = readStringField(error, "message");
+        if (!errorMessage.isBlank()) {
+            return "Error: " + errorMessage;
+        }
+
+        JsonObject incompleteDetails = getObject(jsonResponse, "incomplete_details");
+        String incompleteReason = readStringField(incompleteDetails, "reason");
+        if (!incompleteReason.isBlank()) {
+            return "Error: Provider returned an incomplete response (" + incompleteReason + ").";
+        }
+
+        LOGGER.warn("Responses API result did not include output text: {}", rawResponseBody);
+        return "Error: Provider returned no output text.";
+    }
+
+    private static String extractChatCompletionsText(JsonObject jsonResponse, String rawResponseBody) {
+        JsonArray choices = getArray(jsonResponse, "choices");
+        if (choices == null || choices.isEmpty() || !choices.get(0).isJsonObject()) {
             LOGGER.warn("OpenAI-compatible response did not include choices: {}", rawResponseBody);
             return "Error: Provider returned no choices.";
         }
 
         JsonObject choice = choices.get(0).getAsJsonObject();
-        JsonObject message = choice.getAsJsonObject("message");
+        JsonObject message = getObject(choice, "message");
         if (message != null) {
-            String content = readStringField(message, "content");
+            String content = readContentField(message, "content");
             if (!content.isBlank()) {
                 return content;
             }
@@ -128,25 +292,77 @@ public class GenericOpenAIClient implements LLMClient {
         return "Error: Provider returned an empty message content.";
     }
 
+    private static String readContentField(JsonObject object, String fieldName) {
+        if (object == null || !object.has(fieldName)) {
+            return "";
+        }
+
+        JsonElement content = object.get(fieldName);
+        if (content == null || content.isJsonNull()) {
+            return "";
+        }
+        if (content.isJsonPrimitive()) {
+            return content.getAsString();
+        }
+        if (!content.isJsonArray()) {
+            return "";
+        }
+
+        StringBuilder text = new StringBuilder();
+        for (JsonElement part : content.getAsJsonArray()) {
+            if (part.isJsonPrimitive()) {
+                appendText(text, part.getAsString());
+            } else if (part.isJsonObject()) {
+                appendText(text, readStringField(part.getAsJsonObject(), "text"));
+            }
+        }
+        return text.toString();
+    }
+
+    private static void appendText(StringBuilder destination, String value) {
+        if (value != null && !value.isEmpty()) {
+            destination.append(value);
+        }
+    }
+
+    private static JsonArray getArray(JsonObject object, String fieldName) {
+        if (object == null || !object.has(fieldName) || !object.get(fieldName).isJsonArray()) {
+            return null;
+        }
+        return object.getAsJsonArray(fieldName);
+    }
+
+    private static JsonObject getObject(JsonObject object, String fieldName) {
+        if (object == null || !object.has(fieldName) || !object.get(fieldName).isJsonObject()) {
+            return null;
+        }
+        return object.getAsJsonObject(fieldName);
+    }
+
     private static String readStringField(JsonObject object, String fieldName) {
         if (object == null || !object.has(fieldName)) {
             return "";
         }
         JsonElement element = object.get(fieldName);
-        if (element == null || element.isJsonNull()) {
+        if (element == null || element.isJsonNull() || !element.isJsonPrimitive()) {
             return "";
         }
-        if (element.isJsonPrimitive()) {
-            return element.getAsString();
-        }
-        return element.toString();
+        return element.getAsString();
+    }
+
+    private static String formatHttpError(ApiResponse response) {
+        return "Error: " + response.endpoint().displayName + " returned HTTP "
+                + response.statusCode() + " - " + response.body();
+    }
+
+    private static String formatCombinedHttpError(ApiResponse primary, ApiResponse alternate) {
+        return formatHttpError(primary) + "; " + alternate.endpoint().displayName
+                + " also returned HTTP " + alternate.statusCode() + " - " + alternate.body();
     }
 
     /**
      * Checks if the API is reachable and the key is valid by making a
      * quick, lightweight request to the models endpoint.
-     *
-     * @return true if the API returns a 200 status code, false otherwise.
      */
     @Override
     public boolean isReachable() {
@@ -159,8 +375,7 @@ public class GenericOpenAIClient implements LLMClient {
                 requestBuilder.header("Authorization", "Bearer " + apiKey);
             }
 
-            HttpRequest request = requestBuilder.build();
-            HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
+            HttpResponse<String> response = client.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
             return response.statusCode() == 200;
         } catch (Exception e) {
             return false;
@@ -170,5 +385,28 @@ public class GenericOpenAIClient implements LLMClient {
     @Override
     public String getProvider() {
         return "Generic OpenAI Compatible";
+    }
+
+    private enum ApiEndpoint {
+        CHAT_COMPLETIONS("chat/completions", "Chat Completions"),
+        RESPONSES("responses", "Responses API");
+
+        private final String path;
+        private final String displayName;
+
+        ApiEndpoint(String path, String displayName) {
+            this.path = path;
+            this.displayName = displayName;
+        }
+
+        private ApiEndpoint alternate() {
+            return this == CHAT_COMPLETIONS ? RESPONSES : CHAT_COMPLETIONS;
+        }
+    }
+
+    private record ApiResponse(ApiEndpoint endpoint, int statusCode, String body) {
+        private boolean isSuccessful() {
+            return statusCode >= 200 && statusCode < 300;
+        }
     }
 }

--- a/src/main/java/net/shasankp000/ServiceLLMClients/GenericOpenAIModelFetcher.java
+++ b/src/main/java/net/shasankp000/ServiceLLMClients/GenericOpenAIModelFetcher.java
@@ -37,6 +37,7 @@ public class GenericOpenAIModelFetcher implements ModelFetcher {
         String normalized = baseUrl.trim().replaceAll("/+$", "");
         normalized = normalized.replaceAll("/chat/completions$", "");
         normalized = normalized.replaceAll("/completions$", "");
+        normalized = normalized.replaceAll("/responses$", "");
         normalized = normalized.replaceAll("/embeddings$", "");
         return normalized + "/";
     }

--- a/src/main/java/net/shasankp000/ServiceLLMClients/OpenAIClient.java
+++ b/src/main/java/net/shasankp000/ServiceLLMClients/OpenAIClient.java
@@ -1,102 +1,26 @@
 package net.shasankp000.ServiceLLMClients;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublishers;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
-
+/**
+ * OpenAI client using the Responses API by default, with automatic fallback to
+ * Chat Completions for models that do not support Responses.
+ */
 public class OpenAIClient implements LLMClient {
-    private final String apiKey;
-    private final String modelName; // New field for the model name
-    private final HttpClient client;
-    public static final Logger LOGGER = LoggerFactory.getLogger("OpenAI-Client");
+    private static final String OPENAI_RESPONSES_URL = "https://api.openai.com/v1/responses";
+
+    private final GenericOpenAIClient delegate;
 
     public OpenAIClient(String apiKey, String modelName) {
-        this.apiKey = apiKey;
-        this.modelName = modelName; // Initialize the new field
-        this.client = HttpClient.newHttpClient();
+        this.delegate = new GenericOpenAIClient(apiKey, modelName, OPENAI_RESPONSES_URL);
     }
 
     @Override
     public String sendPrompt(String systemPrompt, String userPrompt) {
-        try {
-            // Construct the request body for chat completions
-            JsonObject requestBody = new JsonObject();
-            requestBody.addProperty("model", this.modelName);
-
-            JsonArray messages = new JsonArray();
-
-            // 1. Create the system message object and add it to the array
-            JsonObject systemMessage = new JsonObject();
-            systemMessage.addProperty("role", "system");
-            systemMessage.addProperty("content", systemPrompt);
-            messages.add(systemMessage);
-
-            // 2. Create the user message object and add it to the array
-            JsonObject userMessage = new JsonObject();
-            userMessage.addProperty("role", "user");
-            userMessage.addProperty("content", userPrompt);
-            messages.add(userMessage);
-
-            requestBody.add("messages", messages);
-            requestBody.addProperty("max_tokens", 150);
-
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create("https://api.openai.com/v1/chat/completions"))
-                    .header("Authorization", "Bearer " + apiKey)
-                    .header("Content-Type", "application/json")
-                    .POST(BodyPublishers.ofString(requestBody.toString()))
-                    .build();
-
-            HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
-
-            // Handle HTTP error codes
-            if (response.statusCode() != 200) {
-                return "Error: " + response.statusCode() + " - " + response.body();
-            }
-
-            // Parse the JSON response
-            JsonObject jsonResponse = JsonParser.parseString(response.body()).getAsJsonObject();
-
-            // Extract the content from the chat message
-            return jsonResponse.getAsJsonArray("choices")
-                    .get(0).getAsJsonObject()
-                    .getAsJsonObject("message")
-                    .get("content").getAsString();
-
-        } catch (Exception e) {
-            LOGGER.error("Error in OpenAI Client: {}", e.getMessage());
-            return "Error: " + e.getMessage();
-        }
+        return delegate.sendPrompt(systemPrompt, userPrompt);
     }
 
-    /**
-     * Checks if the OpenAI API is reachable and the key is valid by making a
-     * quick, lightweight request to the models endpoint.
-     *
-     * @return true if the API returns a 200 status code, false otherwise.
-     */
     @Override
     public boolean isReachable() {
-        try {
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create("https://api.openai.com/v1/models"))
-                    .header("Authorization", "Bearer " + apiKey)
-                    .GET()
-                    .build();
-            HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
-            return response.statusCode() == 200;
-        } catch (Exception e) {
-            return false;
-        }
+        return delegate.isReachable();
     }
 
     @Override

--- a/src/test/java/net/shasankp000/ServiceLLMClients/GenericOpenAIClientTest.java
+++ b/src/test/java/net/shasankp000/ServiceLLMClients/GenericOpenAIClientTest.java
@@ -81,8 +81,12 @@ class GenericOpenAIClientTest {
 
         JsonObject request = JsonParser.parseString(responsesRequestBody.get()).getAsJsonObject();
         assertEquals(model, request.get("model").getAsString());
-        assertEquals("system instructions", request.get("instructions").getAsString());
-        assertEquals("hello", request.get("input").getAsString());
+        JsonArray input = request.getAsJsonArray("input");
+        assertEquals(2, input.size());
+        assertEquals("system", input.get(0).getAsJsonObject().get("role").getAsString());
+        assertEquals("system instructions", input.get(0).getAsJsonObject().get("content").getAsString());
+        assertEquals("user", input.get(1).getAsJsonObject().get("role").getAsString());
+        assertEquals("hello", input.get(1).getAsJsonObject().get("content").getAsString());
         assertEquals(1024, request.get("max_output_tokens").getAsInt());
         assertFalse(request.get("store").getAsBoolean());
 

--- a/src/test/java/net/shasankp000/ServiceLLMClients/GenericOpenAIClientTest.java
+++ b/src/test/java/net/shasankp000/ServiceLLMClients/GenericOpenAIClientTest.java
@@ -1,0 +1,249 @@
+package net.shasankp000.ServiceLLMClients;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class GenericOpenAIClientTest {
+    private HttpServer server;
+
+    @AfterEach
+    void stopServer() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void usesChatCompletionsForBaseUrlsThatSupportIt() throws Exception {
+        AtomicInteger chatRequests = new AtomicInteger();
+        AtomicInteger responsesRequests = new AtomicInteger();
+        AtomicReference<String> authorization = new AtomicReference<>();
+
+        server = newServer();
+        server.createContext("/v1/chat/completions", exchange -> {
+            chatRequests.incrementAndGet();
+            authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            respond(exchange, 200, """
+                    {"choices":[{"message":{"content":"chat reply"}}]}
+                    """);
+        });
+        server.createContext("/v1/responses", exchange -> {
+            responsesRequests.incrementAndGet();
+            respond(exchange, 200, responsesBody("responses reply"));
+        });
+        server.start();
+
+        GenericOpenAIClient client = new GenericOpenAIClient("secret", "chat-model", baseUrl());
+
+        assertEquals("chat reply", client.sendPrompt("system", "hello"));
+        assertEquals(1, chatRequests.get());
+        assertEquals(0, responsesRequests.get());
+        assertEquals("Bearer secret", authorization.get());
+    }
+
+    @Test
+    void fallsBackToResponsesAndRemembersItForTheModel() throws Exception {
+        AtomicInteger chatRequests = new AtomicInteger();
+        AtomicInteger responsesRequests = new AtomicInteger();
+        AtomicReference<String> responsesRequestBody = new AtomicReference<>();
+
+        server = newServer();
+        server.createContext("/v1/chat/completions", exchange -> {
+            chatRequests.incrementAndGet();
+            respond(exchange, 400, "{\"error\":{\"message\":\"model requires Responses API\"}}");
+        });
+        server.createContext("/v1/responses", exchange -> {
+            responsesRequests.incrementAndGet();
+            responsesRequestBody.set(readBody(exchange));
+            respond(exchange, 200, responsesBody("responses reply"));
+        });
+        server.start();
+
+        String model = "responses-only-model";
+        GenericOpenAIClient firstClient = new GenericOpenAIClient("secret", model, baseUrl());
+        assertEquals("responses reply", firstClient.sendPrompt("system instructions", "hello"));
+
+        JsonObject request = JsonParser.parseString(responsesRequestBody.get()).getAsJsonObject();
+        assertEquals(model, request.get("model").getAsString());
+        assertEquals("system instructions", request.get("instructions").getAsString());
+        assertEquals("hello", request.get("input").getAsString());
+        assertEquals(1024, request.get("max_output_tokens").getAsInt());
+        assertFalse(request.get("store").getAsBoolean());
+
+        GenericOpenAIClient secondClient = new GenericOpenAIClient("secret", model, baseUrl());
+        assertEquals("responses reply", secondClient.sendPrompt("system instructions", "again"));
+
+        assertEquals(1, chatRequests.get());
+        assertEquals(2, responsesRequests.get());
+    }
+
+    @Test
+    void doesNotCacheFallbackForPromptSpecificBadRequests() throws Exception {
+        AtomicInteger chatRequests = new AtomicInteger();
+        AtomicInteger responsesRequests = new AtomicInteger();
+
+        server = newServer();
+        server.createContext("/v1/chat/completions", exchange -> {
+            chatRequests.incrementAndGet();
+            respond(exchange, 400, "{\"error\":{\"code\":\"context_length_exceeded\"}}");
+        });
+        server.createContext("/v1/responses", exchange -> {
+            responsesRequests.incrementAndGet();
+            respond(exchange, 200, responsesBody("responses reply"));
+        });
+        server.start();
+
+        String model = "prompt-error-model";
+        assertEquals("responses reply",
+                new GenericOpenAIClient("secret", model, baseUrl()).sendPrompt("system", "first"));
+        assertEquals("responses reply",
+                new GenericOpenAIClient("secret", model, baseUrl()).sendPrompt("system", "second"));
+
+        assertEquals(2, chatRequests.get());
+        assertEquals(2, responsesRequests.get());
+    }
+
+    @Test
+    void fullResponsesUrlSelectsResponsesApiImmediately() throws Exception {
+        AtomicInteger chatRequests = new AtomicInteger();
+        AtomicInteger responsesRequests = new AtomicInteger();
+        AtomicInteger modelRequests = new AtomicInteger();
+
+        server = newServer();
+        server.createContext("/v1/chat/completions", exchange -> {
+            chatRequests.incrementAndGet();
+            respond(exchange, 200, "{\"choices\":[{\"message\":{\"content\":\"chat reply\"}}]}");
+        });
+        server.createContext("/v1/responses", exchange -> {
+            responsesRequests.incrementAndGet();
+            respond(exchange, 200, responsesBody("first ", "second"));
+        });
+        server.createContext("/v1/models", exchange -> {
+            modelRequests.incrementAndGet();
+            respond(exchange, 200, "{\"data\":[{\"id\":\"explicit-responses-model\"}]}");
+        });
+        server.start();
+
+        String responsesUrl = baseUrl() + "/responses";
+        GenericOpenAIClient client = new GenericOpenAIClient(
+                "secret", "explicit-responses-model", responsesUrl);
+
+        assertTrue(client.isReachable());
+        assertEquals(List.of("explicit-responses-model"),
+                new GenericOpenAIModelFetcher(responsesUrl).fetchModels("secret"));
+        assertEquals("first second", client.sendPrompt("system", "hello"));
+        assertEquals(0, chatRequests.get());
+        assertEquals(1, responsesRequests.get());
+        assertEquals(2, modelRequests.get());
+    }
+
+    @Test
+    void remembersChatFallbackForExplicitResponsesUrls() throws Exception {
+        AtomicInteger chatRequests = new AtomicInteger();
+        AtomicInteger responsesRequests = new AtomicInteger();
+
+        server = newServer();
+        server.createContext("/v1/responses", exchange -> {
+            responsesRequests.incrementAndGet();
+            respond(exchange, 400, "{\"error\":{\"message\":\"model only supports Chat Completions\"}}");
+        });
+        server.createContext("/v1/chat/completions", exchange -> {
+            chatRequests.incrementAndGet();
+            respond(exchange, 200, "{\"choices\":[{\"message\":{\"content\":\"chat reply\"}}]}");
+        });
+        server.start();
+
+        String responsesUrl = baseUrl() + "/responses";
+        String model = "chat-only-model";
+        assertEquals("chat reply",
+                new GenericOpenAIClient("secret", model, responsesUrl).sendPrompt("system", "first"));
+        assertEquals("chat reply",
+                new GenericOpenAIClient("secret", model, responsesUrl).sendPrompt("system", "second"));
+
+        assertEquals(1, responsesRequests.get());
+        assertEquals(2, chatRequests.get());
+    }
+
+    @Test
+    void doesNotRetryAuthenticationErrorsAgainstAnotherEndpoint() throws Exception {
+        AtomicInteger responsesRequests = new AtomicInteger();
+
+        server = newServer();
+        server.createContext("/v1/chat/completions", exchange ->
+                respond(exchange, 401, "{\"error\":{\"message\":\"invalid key\"}}"));
+        server.createContext("/v1/responses", exchange -> {
+            responsesRequests.incrementAndGet();
+            respond(exchange, 200, responsesBody("should not be called"));
+        });
+        server.start();
+
+        GenericOpenAIClient client = new GenericOpenAIClient("bad-key", "auth-model", baseUrl());
+        String result = client.sendPrompt("system", "hello");
+
+        assertTrue(result.contains("HTTP 401"));
+        assertEquals(0, responsesRequests.get());
+    }
+
+    private HttpServer newServer() throws IOException {
+        return HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+    }
+
+    private String baseUrl() {
+        return "http://127.0.0.1:" + server.getAddress().getPort() + "/v1";
+    }
+
+    private static String responsesBody(String... textParts) {
+        JsonArray content = new JsonArray();
+        for (String text : textParts) {
+            JsonObject outputText = new JsonObject();
+            outputText.addProperty("type", "output_text");
+            outputText.addProperty("text", text);
+            content.add(outputText);
+        }
+
+        JsonObject reasoning = new JsonObject();
+        reasoning.addProperty("type", "reasoning");
+        reasoning.add("content", new JsonArray());
+
+        JsonObject message = new JsonObject();
+        message.addProperty("type", "message");
+        message.add("content", content);
+
+        JsonArray output = new JsonArray();
+        output.add(reasoning);
+        output.add(message);
+
+        JsonObject response = new JsonObject();
+        response.add("output", output);
+        return response.toString();
+    }
+
+    private static String readBody(HttpExchange exchange) throws IOException {
+        return new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    private static void respond(HttpExchange exchange, int statusCode, String body) throws IOException {
+        byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
+        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.sendResponseHeaders(statusCode, bytes.length);
+        try (exchange; var responseBody = exchange.getResponseBody()) {
+            responseBody.write(bytes);
+        }
+    }
+}

--- a/src/test/java/net/shasankp000/ServiceLLMClients/GenericOpenAIClientTest.java
+++ b/src/test/java/net/shasankp000/ServiceLLMClients/GenericOpenAIClientTest.java
@@ -34,11 +34,13 @@ class GenericOpenAIClientTest {
         AtomicInteger chatRequests = new AtomicInteger();
         AtomicInteger responsesRequests = new AtomicInteger();
         AtomicReference<String> authorization = new AtomicReference<>();
+        AtomicReference<String> chatRequestBody = new AtomicReference<>();
 
         server = newServer();
         server.createContext("/v1/chat/completions", exchange -> {
             chatRequests.incrementAndGet();
             authorization.set(exchange.getRequestHeaders().getFirst("Authorization"));
+            chatRequestBody.set(readBody(exchange));
             respond(exchange, 200, """
                     {"choices":[{"message":{"content":"chat reply"}}]}
                     """);
@@ -55,6 +57,8 @@ class GenericOpenAIClientTest {
         assertEquals(1, chatRequests.get());
         assertEquals(0, responsesRequests.get());
         assertEquals("Bearer secret", authorization.get());
+        assertFalse(JsonParser.parseString(chatRequestBody.get())
+                .getAsJsonObject().get("stream").getAsBoolean());
     }
 
     @Test
@@ -89,6 +93,7 @@ class GenericOpenAIClientTest {
         assertEquals("hello", input.get(1).getAsJsonObject().get("content").getAsString());
         assertEquals(1024, request.get("max_output_tokens").getAsInt());
         assertFalse(request.get("store").getAsBoolean());
+        assertFalse(request.get("stream").getAsBoolean());
 
         GenericOpenAIClient secondClient = new GenericOpenAIClient("secret", model, baseUrl());
         assertEquals("responses reply", secondClient.sendPrompt("system instructions", "again"));
@@ -155,6 +160,62 @@ class GenericOpenAIClientTest {
         assertEquals(0, chatRequests.get());
         assertEquals(1, responsesRequests.get());
         assertEquals(2, modelRequests.get());
+    }
+
+    @Test
+    void parsesResponsesEventStreamWhenGatewayStreamsAnyway() throws Exception {
+        server = newServer();
+        server.createContext("/v1/responses", exchange -> respond(
+                exchange,
+                200,
+                """
+                        event: response.output_text.delta
+                        data: {"type":"response.output_text.delta","delta":"Hello"}
+
+                        event: response.output_text.delta
+                        data: {"type":"response.output_text.delta","delta":" world"}
+
+                        data: [DONE]
+
+                        """,
+                "text/event-stream"));
+        server.start();
+
+        GenericOpenAIClient client = new GenericOpenAIClient(
+                "secret", "streaming-responses-model", baseUrl() + "/responses");
+
+        assertEquals("Hello world", client.sendPrompt("system", "hello"));
+    }
+
+    @Test
+    void extractsTextFromCompletedEventAfterLifecycleEvents() throws Exception {
+        JsonObject completedEvent = new JsonObject();
+        completedEvent.addProperty("type", "response.completed");
+        completedEvent.add("response", JsonParser.parseString(responsesBody("completed reply")));
+
+        server = newServer();
+        server.createContext("/v1/responses", exchange -> respond(
+                exchange,
+                200,
+                """
+                        data: {"type":"response.created","response":{"output":[]}}
+
+                        data: {"type":"response.in_progress","response":{"output":[]}}
+
+                        data: {"type":"response.output_item.added","item":{"type":"message","content":[]}}
+
+                        data: %s
+
+                        data: [DONE]
+
+                        """.formatted(completedEvent),
+                "text/event-stream"));
+        server.start();
+
+        GenericOpenAIClient client = new GenericOpenAIClient(
+                "secret", "completed-event-model", baseUrl() + "/responses");
+
+        assertEquals("completed reply", client.sendPrompt("system", "hello"));
     }
 
     @Test
@@ -243,8 +304,13 @@ class GenericOpenAIClientTest {
     }
 
     private static void respond(HttpExchange exchange, int statusCode, String body) throws IOException {
+        respond(exchange, statusCode, body, "application/json");
+    }
+
+    private static void respond(HttpExchange exchange, int statusCode, String body, String contentType)
+            throws IOException {
         byte[] bytes = body.getBytes(StandardCharsets.UTF_8);
-        exchange.getResponseHeaders().set("Content-Type", "application/json");
+        exchange.getResponseHeaders().set("Content-Type", contentType);
         exchange.sendResponseHeaders(statusCode, bytes.length);
         try (exchange; var responseBody = exchange.getResponseBody()) {
             responseBody.write(bytes);


### PR DESCRIPTION
## Summary

- add `POST /responses` support to the generic OpenAI-compatible client
- keep Chat Completions as the default for custom base URLs, then retry Responses for endpoint/model compatibility errors
- allow a URL ending in `/responses` to select Responses first
- use Responses first for the built-in OpenAI provider, with Chat Completions fallback for legacy models
- send Responses input as a portable system/user message list for LiteLLM compatibility
- explicitly request `stream: false`, while accepting SSE from gateways that stream anyway
- parse Responses deltas, completed events, typed output items, multipart `output_text`, refusals, and Chat-style stream chunks
- normalize `/responses` URLs for model discovery and embedding endpoint derivation

## Compatibility behavior

Authentication, authorization, and rate-limit failures are returned directly and are not retried against another endpoint. Endpoint/model compatibility failures can fall back to the alternate API. Prompt-specific `400` failures do not permanently change routing unless the error explicitly identifies an endpoint incompatibility.

## Tests

Local HTTP-server coverage includes:

- Chat Completions without unnecessary fallback
- Chat Completions → Responses fallback and remembered routing
- Responses request message-list structure
- explicit `/responses` URLs
- Responses → Chat Completions fallback and remembered routing
- SSE `response.output_text.delta` streams
- SSE lifecycle events followed by `response.completed`
- exact multipart output text concatenation
- model discovery from a configured `/responses` URL
- authentication failures without fallback
- prompt-specific errors without persistent routing changes

Validated with Java 25 using `./gradlew test --no-daemon`. Also runtime-tested against a LiteLLM/ChatGPT Responses route that requires list input and returns SSE lifecycle/completion events.
