### PR TITLE
fix/improve mining for the bot

### DIFF
--- a/src/main/java/net/shasankp000/AIPlayer.java
+++ b/src/main/java/net/shasankp000/AIPlayer.java
@@ -31,6 +31,7 @@ import net.shasankp000.Network.SaveConfigPayload;
 import net.shasankp000.Network.SaveCustomProviderPayload;
 import net.shasankp000.Network.configNetworkManager;
 import net.shasankp000.PlayerUtils.FoodConsumptionTool;
+import net.shasankp000.PlayerUtils.MiningTool;
 import net.shasankp000.PathFinding.NavigationService;
 import net.shasankp000.WebSearch.AISearchConfig;
 import org.slf4j.Logger;
@@ -105,6 +106,7 @@ public class AIPlayer implements ModInitializer {
 		// an item while sneaking near the bot, driving the two-phase chat-based trade flow.
 		TradeListener.register();
 		NavigationService.register();
+		MiningTool.register();
 
 		CompletableFuture.runAsync(() -> {
 
@@ -146,6 +148,7 @@ public class AIPlayer implements ModInitializer {
 		});
 
 		ServerLifecycleEvents.SERVER_STOPPED.register(server -> {
+			MiningTool.cancelAll(server, "Server stopped");
 			NavigationService.cancelAll(server, "Server stopped");
 			FoodConsumptionTool.reset();
 

--- a/src/main/java/net/shasankp000/Commands/modCommandRegistry.java
+++ b/src/main/java/net/shasankp000/Commands/modCommandRegistry.java
@@ -578,7 +578,10 @@ public class modCommandRegistry {
                                                                             int x = IntegerArgumentType.getInteger(context, "x");
                                                                             int y = IntegerArgumentType.getInteger(context, "y");
                                                                             int z = IntegerArgumentType.getInteger(context, "z");
-                                                                            MiningTool.mineBlock(bot, new BlockPos(x, y, z));
+                                                                            CommandSourceStack source = context.getSource();
+                                                                            MiningTool.mineBlock(bot, new BlockPos(x, y, z))
+                                                                                    .thenAccept(result -> ChatUtils.sendSystemMessage(
+                                                                                            source, result.functionMessage()));
 
                                                                             return 1;
                                                                         })

--- a/src/main/java/net/shasankp000/FunctionCaller/FunctionCallerV2.java
+++ b/src/main/java/net/shasankp000/FunctionCaller/FunctionCallerV2.java
@@ -470,35 +470,6 @@ public class FunctionCallerV2 {
             getFunctionOutput("Now facing cardinal direction: " + Objects.requireNonNull(botSource.getPlayer()).getNearestViewDirection().getName() + " which is in " + Objects.requireNonNull(botSource.getPlayer()).getNearestViewDirection().getAxis().getSerializedName() + " axis.");
         }
 
-        /** mineBlock: break block **/
-        private static void mineBlock(int targetX, int targetY, int targetZ) {
-            System.out.println("Mining block at: " + targetX + ", " + targetY + ", " + targetZ);
-            if (botSource == null || botSource.getPlayer() == null) {
-                getFunctionOutput("Bot not found.");
-                return;
-            }
-            try {
-                // ✅ Use CompletableFuture.get() to wait for completion
-                CompletableFuture<String> miningFuture = CompletableFuture.supplyAsync(() -> {
-                    try {
-                        return MiningTool.mineBlock(
-                                Objects.requireNonNull(botSource.getPlayer()),
-                                new BlockPos(targetX, targetY, targetZ)
-                        ).get();
-                    } catch (Exception e) {
-                        logger.error("Failed to mine block: {}", e.getMessage(), e);
-                        return "⚠️ Failed to mine block: " + e.getMessage();
-                    }
-                });
-                // Wait for result with timeout
-                String result = miningFuture.get(10, TimeUnit.SECONDS);
-                getFunctionOutput(result);
-            } catch (Exception e) {
-                logger.error("Error in mineBlock: ", e);
-                getFunctionOutput("⚠️ Failed to mine block: " + e.getMessage());
-            }
-        }
-
         /** placeBlock: place block at coordinates **/
         private static void placeBlock(int targetX, int targetY, int targetZ, String blockType) {
             System.out.println("Placing block " + blockType + " at: " + targetX + ", " + targetY + ", " + targetZ);
@@ -1716,6 +1687,34 @@ public class FunctionCallerV2 {
     }
 
     private static CompletableFuture<Void> callFunction(String functionName, Map<String, String> paramMap, Map<String, Object> state) {
+        if ("mineBlock".equals(functionName)) {
+            try {
+                int targetX = Integer.parseInt(resolvePlaceholder(paramMap.get("targetX"), state));
+                int targetY = Integer.parseInt(resolvePlaceholder(paramMap.get("targetY"), state));
+                int targetZ = Integer.parseInt(resolvePlaceholder(paramMap.get("targetZ"), state));
+                logger.info("Calling method: mineBlock with targetX={} targetY={} targetZ={}",
+                        targetX, targetY, targetZ);
+                if (botSource == null || botSource.getPlayer() == null) {
+                    getFunctionOutput("⚠️ Failed to mine block: Bot not found");
+                    return CompletableFuture.completedFuture(null);
+                }
+                return MiningTool.mineBlock(botSource.getPlayer(), new BlockPos(targetX, targetY, targetZ))
+                        .handle((result, error) -> {
+                            if (error != null) {
+                                logger.error("Mining failed", error);
+                                getFunctionOutput("⚠️ Failed to mine block: " + error.getMessage());
+                            } else {
+                                getFunctionOutput(result.functionMessage());
+                            }
+                            return null;
+                        });
+            } catch (Exception e) {
+                logger.error("Could not start mining", e);
+                getFunctionOutput("⚠️ Failed to mine block: " + e.getMessage());
+                return CompletableFuture.completedFuture(null);
+            }
+        }
+
         return CompletableFuture.runAsync(() -> {
             logger.info("🔧 callFunction: {} with params: {}", functionName, paramMap);
 
@@ -1764,13 +1763,6 @@ public class FunctionCallerV2 {
                     String cardinalDirection = resolvePlaceholder(paramMap.get("cardinalDirection"), state);
                     logger.info("Calling method: look with cardinal direction={}", cardinalDirection);
                     Tools.look(cardinalDirection);
-                }
-                case "mineBlock" -> {
-                    int targetX = Integer.parseInt(resolvePlaceholder(paramMap.get("targetX"), state));
-                    int targetY = Integer.parseInt(resolvePlaceholder(paramMap.get("targetY"), state));
-                    int targetZ = Integer.parseInt(resolvePlaceholder(paramMap.get("targetZ"), state));
-                    logger.info("Calling method: mineBlock with targetX={} targetY={} targetZ={}", targetX, targetY, targetZ);
-                    Tools.mineBlock(targetX, targetY, targetZ);
                 }
                 case "placeBlock" -> {
                     int targetX = Integer.parseInt(resolvePlaceholder(paramMap.get("targetX"), state));

--- a/src/main/java/net/shasankp000/PathFinding/SuspensionReason.java
+++ b/src/main/java/net/shasankp000/PathFinding/SuspensionReason.java
@@ -3,6 +3,7 @@ package net.shasankp000.PathFinding;
 /** Idempotent reasons that temporarily yield navigation's movement ownership. */
 public enum SuspensionReason {
     EATING,
+    MINING,
     TRADE,
     THREAT,
     COMBAT,

--- a/src/main/java/net/shasankp000/PlayerUtils/FoodConsumptionTool.java
+++ b/src/main/java/net/shasankp000/PlayerUtils/FoodConsumptionTool.java
@@ -249,7 +249,8 @@ public final class FoodConsumptionTool {
         savedActions.copyFrom(liveActions);
         liveActions.stopAll();
         if (bot.isUsingItem()) bot.stopUsingItem();
-        return new PausedActions(savedActions, wasSprinting, wasSneaking);
+        return new PausedActions(savedActions, wasSprinting, wasSneaking,
+                MiningTool.isMining(bot.getUUID()));
     }
 
     private static void restoreSession(ConsumptionSession session) {
@@ -264,7 +265,13 @@ public final class FoodConsumptionTool {
                 && !session.bot.hasDisconnected()
                 && session.pausedActions != null
                 && session.bot instanceof ServerPlayerInterface playerInterface) {
-            playerInterface.getActionPack().copyFrom(session.pausedActions.actionPack);
+            EntityPlayerActionPack liveActions = playerInterface.getActionPack();
+            liveActions.copyFrom(session.pausedActions.actionPack);
+            if (session.pausedActions.miningWasActive) {
+                // Mining owns ATTACK and will re-establish it on its next server tick
+                // if the generation is still active. Never restore a stale attack.
+                liveActions.start(EntityPlayerActionPack.ActionType.ATTACK, null);
+            }
             session.bot.setShiftKeyDown(session.pausedActions.wasSneaking);
             session.bot.setSprinting(session.pausedActions.wasSprinting);
         }
@@ -345,7 +352,8 @@ public final class FoodConsumptionTool {
     private record PausedActions(
             EntityPlayerActionPack actionPack,
             boolean wasSprinting,
-            boolean wasSneaking
+            boolean wasSneaking,
+            boolean miningWasActive
     ) {}
 
     private record FoodCandidate(int slot, String itemId, int nutrition, float saturation) {

--- a/src/main/java/net/shasankp000/PlayerUtils/MiningResult.java
+++ b/src/main/java/net/shasankp000/PlayerUtils/MiningResult.java
@@ -1,0 +1,36 @@
+package net.shasankp000.PlayerUtils;
+
+import net.minecraft.core.BlockPos;
+
+/** Terminal result of a server-authoritative mining session. */
+public record MiningResult(Status status, BlockPos target, String message) {
+
+    public enum Status {
+        SUCCESS,
+        CANCELLED,
+        TIMED_OUT,
+        INVALID_TARGET,
+        OUT_OF_RANGE,
+        UNBREAKABLE,
+        PLAYER_UNAVAILABLE,
+        TARGET_CHANGED,
+        FAILED
+    }
+
+    public static MiningResult success(BlockPos target) {
+        return new MiningResult(Status.SUCCESS, target, "Mining complete!");
+    }
+
+    public static MiningResult failure(Status status, BlockPos target, String message) {
+        if (status == Status.SUCCESS) throw new IllegalArgumentException("Failure cannot use SUCCESS status");
+        return new MiningResult(status, target, message);
+    }
+
+    public boolean succeeded() {
+        return status == Status.SUCCESS;
+    }
+
+    public String functionMessage() {
+        return succeeded() ? message : "⚠️ Failed to mine block: " + message;
+    }
+}

--- a/src/main/java/net/shasankp000/PlayerUtils/MiningTool.java
+++ b/src/main/java/net/shasankp000/PlayerUtils/MiningTool.java
@@ -1,91 +1,360 @@
 package net.shasankp000.PlayerUtils;
 
-import java.util.concurrent.*;
+import carpet.fakes.ServerPlayerInterface;
+import carpet.helpers.EntityPlayerActionPack;
+import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
 import net.shasankp000.Entity.LookController;
+import net.shasankp000.PathFinding.NavigationService;
+import net.shasankp000.PathFinding.SuspensionReason;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MiningTool {
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
-    private static final long ATTACK_INTERVAL_MS = 200;
-    public static final Logger LOGGER = LoggerFactory.getLogger("mining-tool");
+/** Owns server-authoritative, vanilla-timed mining sessions for fake players. */
+public final class MiningTool {
 
-    public static CompletableFuture<String> mineBlock(ServerPlayer bot, BlockPos targetBlockPos) {
-        CompletableFuture<String> miningResult = new CompletableFuture<>();
-        try {
+    private static final Logger LOGGER = LoggerFactory.getLogger("mining-tool");
+    private static final Map<UUID, MiningSession> SESSIONS = new ConcurrentHashMap<>();
+    private static final AtomicLong GENERATIONS = new AtomicLong();
+    private static final AtomicBoolean REGISTERED = new AtomicBoolean();
+    private static final double MAX_MINING_DISTANCE = 5.0;
+    private static final int MIN_DEADLINE_TICKS = 100;
+    private static final int MAX_DEADLINE_TICKS = 2_400;
+    private static final int DEADLINE_MARGIN_TICKS = 40;
 
+    private MiningTool() {}
 
-                ScheduledExecutorService miningExecutor = Executors.newSingleThreadScheduledExecutor();
-
-                // Step 1: Face the block
-                LookController.faceBlock(bot, targetBlockPos);
-
-                // Step 2: Select best tool
-                BlockState blockState = bot.level().getBlockState(targetBlockPos);
-                ItemStack bestTool = ToolSelector.selectBestToolForBlock(bot, blockState);
-
-                // Step 3: Switch to that tool
-                switchToTool(bot, bestTool);
-
-                // Step 4: Start mining loop
-                ScheduledFuture<?> task = miningExecutor.scheduleAtFixedRate(() -> {
-                    if (FoodConsumptionTool.isConsumptionInProgress(bot.getUUID())) return;
-
-                    MinecraftServer server = bot.level().getServer();
-                    if (server == null) {
-                        miningResult.complete("⚠️ Server not found");
-                        miningExecutor.shutdownNow();
-                        return;
-                    }
-
-                    server.execute(() -> {
-                        BlockState currentState = bot.level().getBlockState(targetBlockPos);
-
-                        if (currentState.isAir()) {
-                            System.out.println("✅ Mining complete!");
-                            miningResult.complete("Mining complete!");
-                            miningExecutor.shutdownNow();
-                            return;
-                        }
-
-                        bot.swing(bot.getUsedItemHand());
-                        bot.gameMode.destroyBlock(targetBlockPos);
-                        System.out.println("⛏️ Mining...");
-                    });
-
-                }, 0, ATTACK_INTERVAL_MS, TimeUnit.MILLISECONDS);
-
-                // In case something else cancels this process
-                miningResult.whenComplete((result, error) -> {
-                    if (!task.isCancelled() && !task.isDone()) {
-                        task.cancel(true);
-                    }
-                    if (!miningExecutor.isShutdown()) {
-                        miningExecutor.shutdownNow();
-                    }
-                });
-
-
+    public static void register() {
+        if (REGISTERED.compareAndSet(false, true)) {
+            ServerTickEvents.END_SERVER_TICK.register(MiningTool::tick);
         }
-        catch (Exception e) {
-            LOGGER.error("Error in mining tool! {}", e.getMessage());
-        }
-
-        return miningResult;
     }
 
-    private static void switchToTool(ServerPlayer bot, ItemStack tool) {
-        for (int i = 0; i < 9; i++) {
-            if (bot.getInventory().getItem(i) == tool) {
-                bot.getInventory().setSelectedSlot(i);
-                break;
+    public static CompletableFuture<MiningResult> mineBlock(ServerPlayer bot, BlockPos targetBlockPos) {
+        if (bot == null || targetBlockPos == null) {
+            return CompletableFuture.completedFuture(MiningResult.failure(
+                    MiningResult.Status.INVALID_TARGET, targetBlockPos, "Bot and target are required"));
+        }
+
+        MinecraftServer server = bot.level().getServer();
+        if (server == null) {
+            return CompletableFuture.completedFuture(MiningResult.failure(
+                    MiningResult.Status.PLAYER_UNAVAILABLE, targetBlockPos, "Server is unavailable"));
+        }
+
+        UUID botId = bot.getUUID();
+        long generation = GENERATIONS.incrementAndGet();
+        BlockPos target = targetBlockPos.immutable();
+        CompletableFuture<MiningResult> future = new CompletableFuture<>();
+        Runnable begin = () -> beginSafely(server, botId, target, generation, future);
+
+        try {
+            if (server.isSameThread()) begin.run();
+            else server.execute(begin);
+        } catch (Throwable throwable) {
+            LOGGER.error("Could not schedule mining for {} at {}", botId, target, throwable);
+            future.complete(MiningResult.failure(
+                    MiningResult.Status.FAILED, target, "Could not schedule mining: " + throwable.getMessage()));
+        }
+
+        future.whenComplete((result, error) -> {
+            if (future.isCancelled()) {
+                cancel(server, botId, generation, "Mining request was cancelled");
+            }
+        });
+        return future;
+    }
+
+    public static void cancelAll(MinecraftServer server, String reason) {
+        if (server == null) return;
+        Runnable cancel = () -> new ArrayList<>(SESSIONS.values()).stream()
+                .filter(session -> session.server == server)
+                .forEach(session -> finish(session, MiningResult.failure(
+                        MiningResult.Status.CANCELLED, session.target, reason)));
+        runOnServer(server, cancel);
+    }
+
+    public static boolean isMining(UUID botId) {
+        return botId != null && SESSIONS.containsKey(botId);
+    }
+
+    static int adaptiveDeadlineTicks(float destroyProgress) {
+        if (!Float.isFinite(destroyProgress) || destroyProgress <= 0.0F) return -1;
+        long expectedTicks = (long) Math.ceil(1.0D / destroyProgress);
+        long deadline = expectedTicks * 2L + DEADLINE_MARGIN_TICKS;
+        return (int) Math.max(MIN_DEADLINE_TICKS, Math.min(MAX_DEADLINE_TICKS, deadline));
+    }
+
+    static boolean generationMatches(long activeGeneration, long callbackGeneration) {
+        return activeGeneration == callbackGeneration;
+    }
+
+    static int advanceActiveTicks(int activeTicks, boolean pausedForFood) {
+        return pausedForFood ? activeTicks : activeTicks + 1;
+    }
+
+    static boolean deadlineExceeded(int activeTicks, int deadlineTicks) {
+        return activeTicks > deadlineTicks;
+    }
+
+    private static void beginSafely(MinecraftServer server, UUID botId, BlockPos target, long generation,
+                                    CompletableFuture<MiningResult> future) {
+        try {
+            beginOnServer(server, botId, target, generation, future);
+        } catch (Throwable throwable) {
+            LOGGER.error("Mining {} failed to initialize for {} at {}", generation, botId, target, throwable);
+            MiningSession session = SESSIONS.get(botId);
+            MiningResult failure = MiningResult.failure(
+                    MiningResult.Status.FAILED, target, "Mining initialization failed: " + throwable.getMessage());
+            if (session != null && generationMatches(session.generation, generation)) finish(session, failure);
+            else future.complete(failure);
+        }
+    }
+
+    private static void beginOnServer(MinecraftServer server, UUID botId, BlockPos target, long generation,
+                                      CompletableFuture<MiningResult> future) {
+        if (future.isDone()) return;
+
+        MiningSession previous = SESSIONS.get(botId);
+        if (previous != null) {
+            finish(previous, MiningResult.failure(
+                    MiningResult.Status.CANCELLED, previous.target, "Replaced by a newer mining request"));
+        }
+
+        ServerPlayer player = server.getPlayerList().getPlayer(botId);
+        MiningResult validationFailure = validateStart(player, target);
+        if (validationFailure != null) {
+            future.complete(validationFailure);
+            return;
+        }
+
+        if (!(player instanceof ServerPlayerInterface playerInterface)) {
+            future.complete(MiningResult.failure(MiningResult.Status.PLAYER_UNAVAILABLE, target,
+                    "Carpet action pack is unavailable"));
+            return;
+        }
+
+        ServerLevel level = player.level();
+        BlockState initialState = level.getBlockState(target);
+        ItemStack bestTool = ToolSelector.selectBestToolForBlock(player, initialState);
+        switchToTool(player, bestTool);
+        float destroyProgress = initialState.getDestroyProgress(player, level, target);
+        int deadlineTicks = adaptiveDeadlineTicks(destroyProgress);
+        if (deadlineTicks < 0) {
+            future.complete(MiningResult.failure(
+                    MiningResult.Status.UNBREAKABLE, target, "Target block cannot be mined"));
+            return;
+        }
+
+        MiningSession session = new MiningSession(botId, server, level.dimension(), target,
+                initialState.getBlock(), generation, deadlineTicks, future);
+        SESSIONS.put(botId, session);
+        NavigationService.suspend(botId, SuspensionReason.MINING);
+        if (FoodConsumptionTool.isConsumptionInProgress(botId)) {
+            session.pausedForFood = true;
+            playerInterface.getActionPack().start(EntityPlayerActionPack.ActionType.ATTACK, null);
+        } else {
+            startAttacking(session, player, playerInterface.getActionPack());
+        }
+        LOGGER.debug("Mining {} started for {} at {} with a {} tick deadline",
+                generation, botId, target, deadlineTicks);
+    }
+
+    private static MiningResult validateStart(ServerPlayer player, BlockPos target) {
+        if (player == null || !player.isAlive() || player.hasDisconnected()) {
+            return MiningResult.failure(
+                    MiningResult.Status.PLAYER_UNAVAILABLE, target, "Player is unavailable");
+        }
+        ServerLevel level = player.level();
+        if (!level.isLoaded(target)) {
+            return MiningResult.failure(
+                    MiningResult.Status.INVALID_TARGET, target, "Target block is not loaded");
+        }
+        if (player.position().distanceTo(Vec3.atCenterOf(target)) > MAX_MINING_DISTANCE) {
+            return MiningResult.failure(
+                    MiningResult.Status.OUT_OF_RANGE, target, "Target is more than five blocks away");
+        }
+        if (level.getBlockState(target).isAir()) {
+            return MiningResult.failure(
+                    MiningResult.Status.INVALID_TARGET, target, "Target is already air");
+        }
+        return null;
+    }
+
+    private static void tick(MinecraftServer server) {
+        if (SESSIONS.isEmpty()) return;
+        for (MiningSession session : new ArrayList<>(SESSIONS.values())) {
+            if (session.server != server || SESSIONS.get(session.botId) != session) continue;
+            try {
+                if (session.future.isDone()) {
+                    finish(session, null);
+                    continue;
+                }
+
+                ServerPlayer player = server.getPlayerList().getPlayer(session.botId);
+                if (player == null || !player.isAlive() || player.hasDisconnected()) {
+                    finish(session, MiningResult.failure(
+                            MiningResult.Status.PLAYER_UNAVAILABLE, session.target, "Player became unavailable"));
+                    continue;
+                }
+                if (player.level().dimension() != session.dimension) {
+                    finish(session, MiningResult.failure(
+                            MiningResult.Status.CANCELLED, session.target, "Player changed dimension"));
+                    continue;
+                }
+
+                ServerLevel level = player.level();
+                if (!level.isLoaded(session.target)) {
+                    finish(session, MiningResult.failure(
+                            MiningResult.Status.INVALID_TARGET, session.target, "Target block became unloaded"));
+                    continue;
+                }
+                if (player.position().distanceTo(Vec3.atCenterOf(session.target)) > MAX_MINING_DISTANCE) {
+                    finish(session, MiningResult.failure(
+                            MiningResult.Status.OUT_OF_RANGE, session.target, "Player moved out of mining range"));
+                    continue;
+                }
+
+                BlockState currentState = level.getBlockState(session.target);
+                if (currentState.isAir()) {
+                    finish(session, MiningResult.success(session.target));
+                    continue;
+                }
+                if (currentState.getBlock() != session.initialBlock) {
+                    finish(session, MiningResult.failure(
+                            MiningResult.Status.TARGET_CHANGED, session.target, "Target block changed while mining"));
+                    continue;
+                }
+                if (!(player instanceof ServerPlayerInterface playerInterface)) {
+                    finish(session, MiningResult.failure(MiningResult.Status.PLAYER_UNAVAILABLE, session.target,
+                            "Carpet action pack became unavailable"));
+                    continue;
+                }
+
+                EntityPlayerActionPack actions = playerInterface.getActionPack();
+                if (FoodConsumptionTool.isConsumptionInProgress(session.botId)) {
+                    if (!session.pausedForFood) {
+                        actions.start(EntityPlayerActionPack.ActionType.ATTACK, null);
+                        session.pausedForFood = true;
+                    }
+                    continue;
+                }
+                if (session.pausedForFood) {
+                    startAttacking(session, player, actions);
+                    session.pausedForFood = false;
+                }
+
+                session.activeTicks = advanceActiveTicks(session.activeTicks, false);
+                if (deadlineExceeded(session.activeTicks, session.deadlineTicks)) {
+                    finish(session, MiningResult.failure(
+                            MiningResult.Status.TIMED_OUT, session.target, "Mining exceeded its adaptive deadline"));
+                }
+            } catch (Throwable throwable) {
+                LOGGER.error("Mining {} failed while ticking", session.generation, throwable);
+                finish(session, MiningResult.failure(MiningResult.Status.FAILED, session.target,
+                        "Mining failed: " + throwable.getMessage()));
             }
         }
     }
 
+    private static void startAttacking(MiningSession session, ServerPlayer player,
+                                       EntityPlayerActionPack actions) {
+        LookController.faceBlock(player, session.target);
+        actions.start(EntityPlayerActionPack.ActionType.ATTACK,
+                EntityPlayerActionPack.Action.continuous());
+    }
+
+    private static void cancel(MinecraftServer server, UUID botId, long generation, String reason) {
+        Runnable cancel = () -> {
+            MiningSession session = SESSIONS.get(botId);
+            if (session != null && generationMatches(session.generation, generation)) {
+                finish(session, MiningResult.failure(
+                        MiningResult.Status.CANCELLED, session.target, reason));
+            }
+        };
+        runOnServer(server, cancel);
+    }
+
+    private static void finish(MiningSession session, MiningResult result) {
+        if (!SESSIONS.remove(session.botId, session)) return;
+        try {
+            ServerPlayer player = session.server.getPlayerList().getPlayer(session.botId);
+            if (player instanceof ServerPlayerInterface playerInterface) {
+                playerInterface.getActionPack().start(EntityPlayerActionPack.ActionType.ATTACK, null);
+            }
+        } catch (Throwable throwable) {
+            LOGGER.warn("Could not release mining attack for {}", session.botId, throwable);
+        }
+        try {
+            NavigationService.resume(session.botId, SuspensionReason.MINING);
+        } catch (Throwable throwable) {
+            LOGGER.warn("Could not resume navigation after mining for {}", session.botId, throwable);
+        } finally {
+            if (result != null && !session.future.isDone()) session.future.complete(result);
+        }
+        LOGGER.debug("Mining {} completed for {}: {}", session.generation, session.botId,
+                result == null ? "externally completed" : result.status());
+    }
+
+    private static void runOnServer(MinecraftServer server, Runnable task) {
+        try {
+            if (server.isSameThread() || !server.isRunning()) task.run();
+            else server.execute(task);
+        } catch (Throwable throwable) {
+            LOGGER.error("Could not schedule mining cleanup", throwable);
+        }
+    }
+
+    private static void switchToTool(ServerPlayer bot, ItemStack tool) {
+        for (int slot = 0; slot < 9; slot++) {
+            if (bot.getInventory().getItem(slot) == tool) {
+                bot.getInventory().setSelectedSlot(slot);
+                return;
+            }
+        }
+    }
+
+    private static final class MiningSession {
+        final UUID botId;
+        final MinecraftServer server;
+        final ResourceKey<Level> dimension;
+        final BlockPos target;
+        final Block initialBlock;
+        final long generation;
+        final int deadlineTicks;
+        final CompletableFuture<MiningResult> future;
+        int activeTicks;
+        boolean pausedForFood;
+
+        MiningSession(UUID botId, MinecraftServer server, ResourceKey<Level> dimension, BlockPos target,
+                      Block initialBlock, long generation, int deadlineTicks,
+                      CompletableFuture<MiningResult> future) {
+            this.botId = Objects.requireNonNull(botId);
+            this.server = Objects.requireNonNull(server);
+            this.dimension = Objects.requireNonNull(dimension);
+            this.target = Objects.requireNonNull(target);
+            this.initialBlock = Objects.requireNonNull(initialBlock);
+            this.generation = generation;
+            this.deadlineTicks = deadlineTicks;
+            this.future = Objects.requireNonNull(future);
+        }
+    }
 }

--- a/src/test/java/net/shasankp000/PlayerUtils/MiningToolTest.java
+++ b/src/test/java/net/shasankp000/PlayerUtils/MiningToolTest.java
@@ -1,0 +1,65 @@
+package net.shasankp000.PlayerUtils;
+
+import net.minecraft.core.BlockPos;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MiningToolTest {
+
+    @Test
+    void rejectsNonPositiveAndNonFiniteDestroyProgress() {
+        assertEquals(-1, MiningTool.adaptiveDeadlineTicks(0.0F));
+        assertEquals(-1, MiningTool.adaptiveDeadlineTicks(-1.0F));
+        assertEquals(-1, MiningTool.adaptiveDeadlineTicks(Float.NaN));
+        assertEquals(-1, MiningTool.adaptiveDeadlineTicks(Float.POSITIVE_INFINITY));
+    }
+
+    @Test
+    void adaptiveDeadlineHasFiveSecondFloor() {
+        assertEquals(100, MiningTool.adaptiveDeadlineTicks(1.0F));
+        assertEquals(100, MiningTool.adaptiveDeadlineTicks(0.25F));
+    }
+
+    @Test
+    void adaptiveDeadlineAllowsSlowMiningWithSafetyMargin() {
+        float progressPerTick = 0.01F;
+        int expectedTicks = (int) Math.ceil(1.0D / progressPerTick);
+        assertEquals(expectedTicks * 2 + 40,
+                MiningTool.adaptiveDeadlineTicks(progressPerTick));
+    }
+
+    @Test
+    void adaptiveDeadlineHasTwoMinuteCeiling() {
+        assertEquals(2_400, MiningTool.adaptiveDeadlineTicks(0.00001F));
+    }
+
+    @Test
+    void generationGuardRejectsStaleCancellation() {
+        assertTrue(MiningTool.generationMatches(42L, 42L));
+        assertFalse(MiningTool.generationMatches(43L, 42L));
+    }
+
+    @Test
+    void foodPauseDoesNotConsumeTheMiningDeadline() {
+        assertEquals(75, MiningTool.advanceActiveTicks(75, true));
+        assertEquals(76, MiningTool.advanceActiveTicks(75, false));
+        assertFalse(MiningTool.deadlineExceeded(100, 100));
+        assertTrue(MiningTool.deadlineExceeded(101, 100));
+    }
+
+    @Test
+    void miningResultProvidesStableFunctionCallerMessages() {
+        BlockPos target = new BlockPos(1, 64, 2);
+        MiningResult success = MiningResult.success(target);
+        MiningResult timeout = MiningResult.failure(
+                MiningResult.Status.TIMED_OUT, target, "adaptive deadline reached");
+
+        assertTrue(success.succeeded());
+        assertEquals("Mining complete!", success.functionMessage());
+        assertFalse(timeout.succeeded());
+        assertEquals("⚠️ Failed to mine block: adaptive deadline reached", timeout.functionMessage());
+    }
+}


### PR DESCRIPTION
The mining fix removes leaking threads and uses Minecraft server ticks for normal mining speed. It validates the target, selects the best tool, pauses while eating, times out safely, supports cancellation/replacement, and always cleans up when finished.