### PR TITLE
Restrict AI configuration to operators

### DIFF
--- a/src/main/java/net/shasankp000/Commands/configCommand.java
+++ b/src/main/java/net/shasankp000/Commands/configCommand.java
@@ -2,31 +2,18 @@ package net.shasankp000.Commands;
 
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.shasankp000.Network.configNetworkManager;
-import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.commands.Commands;
 import net.minecraft.server.level.ServerPlayer;
-import net.fabricmc.api.EnvType;
 
 public class configCommand {
 
     public static void register() {
         CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
             dispatcher.register(Commands.literal("configMan")
+                    .requires(source -> configNetworkManager.canManageServerConfig(source.getPlayer()))
                     .executes(context -> {
-                        // Get the player who executed the command.
                         ServerPlayer player = context.getSource().getPlayer();
-
-                        // Check if we're on a dedicated server.
-                        if (FabricLoader.getInstance().getEnvironmentType() == EnvType.SERVER) {
-                            // On a dedicated server, send a packet to the client to open the config GUI.
-                            configNetworkManager.sendOpenConfigPacket(player);
-                        }
-                        else {
-                            // we are on client, send packet to the client to open the config GUI
-
-                            configNetworkManager.sendOpenConfigPacket(player);
-
-                        }
+                        configNetworkManager.sendOpenConfigPacket(player);
 
                         return 1;
                     })

--- a/src/main/java/net/shasankp000/Network/configNetworkManager.java
+++ b/src/main/java/net/shasankp000/Network/configNetworkManager.java
@@ -3,6 +3,7 @@ package net.shasankp000.Network;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.shasankp000.AIPlayer;
@@ -14,6 +15,30 @@ import org.slf4j.LoggerFactory;
 public class configNetworkManager {
 
     public static final Logger LOGGER = LoggerFactory.getLogger("ConfigNetworkMan");
+
+    /**
+     * Returns whether the player may view and update the server's AI configuration.
+     * The server's operator list is authoritative; client-side state is never trusted.
+     */
+    public static boolean canManageServerConfig(ServerPlayer player) {
+        if (player == null) {
+            return false;
+        }
+
+        MinecraftServer server = player.level().getServer();
+        return server != null && server.getPlayerList().isOp(player.nameAndId());
+    }
+
+    private static boolean rejectUnauthorizedConfigChange(ServerPlayer player, String packetType) {
+        if (canManageServerConfig(player)) {
+            return false;
+        }
+
+        LOGGER.warn("Rejected unauthorized {} configuration packet from {} ({})",
+                packetType, player.getName().getString(), player.getUUID());
+        player.sendSystemMessage(Component.literal("You do not have permission to change the server AI configuration."));
+        return true;
+    }
 
     // Called on the server side: sends a packet to the specified player.
     public static void sendOpenConfigPacket(ServerPlayer player) {
@@ -47,13 +72,15 @@ public class configNetworkManager {
     @SuppressWarnings("resource")
     public static void registerServerModelNameSaveReceiver(MinecraftServer server) {
         ServerPlayNetworking.registerGlobalReceiver(SaveConfigPayload.ID, (payload, context) -> {
-            // Retrieve the configuration data from the payload
             String newConfigData = payload.configData();
-            System.out.println("Config data to save: ");
-            System.out.println(newConfigData);
+            ServerPlayer sender = context.player();
 
             // Run the config update on the server thread
             context.server().execute(() -> {
+                if (rejectUnauthorizedConfigChange(sender, "model-selection")) {
+                    return;
+                }
+
                 AIPlayer.CONFIG.setSelectedLanguageModel(newConfigData);
                 AIPlayer.CONFIG.save();
                 CommandSourceStack serverCommandSource = server.createCommandSourceStack().withSuppressedOutput().withMaximumPermission(net.minecraft.server.permissions.PermissionSet.ALL_PERMISSIONS);
@@ -67,9 +94,14 @@ public class configNetworkManager {
         ServerPlayNetworking.registerGlobalReceiver(SaveAPIKeyPayload.ID, (payload, context) -> {
             String provider = payload.provider();
             String newKey = payload.key();
+            ServerPlayer sender = context.player();
 
             // Run the config update on the server thread
             context.server().execute(() -> {
+                if (rejectUnauthorizedConfigChange(sender, "API-key")) {
+                    return;
+                }
+
                 switch (provider) {
                     case "openai":
                         AIPlayer.CONFIG.setOpenAIKey(newKey);
@@ -105,9 +137,14 @@ public class configNetworkManager {
         ServerPlayNetworking.registerGlobalReceiver(SaveCustomProviderPayload.ID, (payload, context) -> {
             String newApiKey = payload.apiKey();
             String newApiUrl = payload.apiUrl();
+            ServerPlayer sender = context.player();
 
             // Run the config update on the server thread
             context.server().execute(() -> {
+                if (rejectUnauthorizedConfigChange(sender, "custom-provider")) {
+                    return;
+                }
+
                 AIPlayer.CONFIG.setCustomApiKey(newApiKey);
                 AIPlayer.CONFIG.setCustomApiUrl(newApiUrl);
                 AIPlayer.CONFIG.save();


### PR DESCRIPTION
Previously, any connected player using a modified client could send configuration packets directly and overwrite the selected model, API keys, or custom-provider settings—even without opening the configuration menu.
Now:
- Only Minecraft operators can run /configMan.
- The server independently checks operator status whenever it receives a configuration packet.
- The check happens immediately before saving, so a player who has just been de-opped is also denied.
- Unauthorized attempts make no configuration changes, notify only that player, and add a safe warning to the server log.
- Submitted API keys, URLs, and configuration values are not written to logs.
- Single-player owners with commands enabled retain access.
This is enforced server-side because client-side restrictions can be bypassed by modified clients. The network payload format remains unchanged, so there are no compatibility or configuration migration requirements.So in plain english this helps for the saftey of the api keys